### PR TITLE
feat: limit history to 80% of total videos and update to 1.1.42

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,9 @@
 # Gemini CLI - Journal des modifications
 
+## [1.1.44] - 2026-02-18
+### Changé
+- **Limite d'historique** : La longueur de l'historique est désormais dynamique et limitée à 80% du nombre total de vidéos en base pour une meilleure gestion de l'espace.
+
 ## [1.1.41] - 2026-02-17
 ### Ajouté
 - **Téléchargement de chaîne** : Ajout d'un bouton "Télécharger la chaîne" dans la vue par chaîne pour faciliter l'archivage complet.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube",
-  "version": "1.1.43",
+  "version": "1.1.44",
   "description": "youtube local",
   "main": "src/index.js",
   "private": true,

--- a/src/db.js
+++ b/src/db.js
@@ -198,8 +198,9 @@ class FileDatabase {
         this.history = this.history.filter(id => id !== videoId);
         // Add to the beginning of history
         this.history.unshift(videoId);
-        // Limit history to 100 items
-        if (this.history.length > 100) {
+        // Limit history to 80% of the total number of videos
+        const limit = Math.floor(this.database.length * 0.8);
+        if (this.history.length > limit && limit > 0) {
             this.history.pop();
         }
         this.saveDatabase();

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -24,38 +24,48 @@ const FileDatabase = require('../src/db.js');
 test('FileDatabase should manage history correctly', (t) => {
     const userDataPath = path.resolve('./test-history-userdata');
     const filesPath = path.resolve('./test-history-files');
+    
+    // Clean start
+    if (fs.existsSync(userDataPath)) fs.rmSync(userDataPath, { recursive: true, force: true });
+    if (fs.existsSync(filesPath)) fs.rmSync(filesPath, { recursive: true, force: true });
+    
     if (!fs.existsSync(userDataPath)) fs.mkdirSync(userDataPath, { recursive: true });
     if (!fs.existsSync(filesPath)) fs.mkdirSync(filesPath, { recursive: true });
     
     const db = new FileDatabase(filesPath);
     
-    // Add dummy file to database
-    db.database.push({
-        fileName: "test [abc].mp4",
-        fileUuid: "uuid-abc",
-        yid: "abc",
-        tags: []
-    });
-    db.database.push({
-        fileName: "test [def].mp4",
-        fileUuid: "uuid-def",
-        yid: "def",
-        tags: []
-    });
+    // Add 10 dummy files to database
+    for (let i = 0; i < 10; i++) {
+        db.database.push({
+            fileName: `test [v${i}].mp4`,
+            fileUuid: `uuid-v${i}`,
+            yid: `v${i}`,
+            tags: []
+        });
+    }
     
-    db.addToHistory("abc");
-    assert.deepStrictEqual(db.history, ["abc"]);
+    // Add 8 items to history (80% of 10)
+    for (let i = 0; i < 8; i++) {
+        db.addToHistory(`v${i}`);
+    }
+    assert.strictEqual(db.history.length, 8);
+    assert.strictEqual(db.history[0], "v7");
     
-    db.addToHistory("def");
-    assert.deepStrictEqual(db.history, ["def", "abc"]);
+    // Add 9th item, it should pop the oldest one
+    db.addToHistory("v8");
+    assert.strictEqual(db.history.length, 8);
+    assert.strictEqual(db.history[0], "v8");
+    assert.strictEqual(db.history[7], "v1");
+    assert.strictEqual(db.history.includes("v0"), false);
     
-    db.addToHistory("abc"); // Move to front
-    assert.deepStrictEqual(db.history, ["abc", "def"]);
+    // Move existing item to front
+    db.addToHistory("v1");
+    assert.strictEqual(db.history.length, 8);
+    assert.strictEqual(db.history[0], "v1");
     
     const historyItems = db.getHistory();
-    assert.strictEqual(historyItems.length, 2);
-    assert.strictEqual(historyItems[0].yid, "abc");
-    assert.strictEqual(historyItems[1].yid, "def");
+    assert.strictEqual(historyItems.length, 8);
+    assert.strictEqual(historyItems[0].yid, "v1");
     
     // Clean up
     fs.rmSync(userDataPath, { recursive: true, force: true });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make history size dynamic by capping it at 80% of the total videos instead of a fixed 100, improving space management as libraries grow. Bumped version to 1.1.44 and updated tests to cover the new behavior.

- **New Features**
  - Limit history to floor(total videos × 0.8) in FileDatabase.addToHistory.
  - Updated tests to verify max size (10 videos → 8 history entries), oldest item removal, and move-to-front behavior.
  - Updated changelog (GEMINI.md) and package version to 1.1.44.

<sup>Written for commit 383fdc0dc442527a2de179f22af1ac47b922e516. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

