### PR TITLE
feat: add video download bar to view.ejs and update to 1.1.45

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,9 @@
 # Gemini CLI - Journal des modifications
 
+## [1.1.45] - 2026-02-19
+### Ajouté
+- **Barre de recherche sur la vue lecture** : Intégration de la barre de téléchargement de vidéos directement dans la vue de lecture pour faciliter le téléchargement sans repasser par l'accueil.
+
 ## [1.1.44] - 2026-02-18
 ### Changé
 - **Limite d'historique** : La longueur de l'historique est désormais dynamique et limitée à 80% du nombre total de vidéos en base pour une meilleure gestion de l'espace.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube",
-  "version": "1.1.44",
+  "version": "1.1.45",
   "description": "youtube local",
   "main": "src/index.js",
   "private": true,

--- a/src/views/view.ejs
+++ b/src/views/view.ejs
@@ -15,6 +15,7 @@
 
     <script src="https://cdn.lr-ingest.com/LogRocket.min.js" crossorigin="anonymous"></script>
     <script>window.LogRocket && window.LogRocket.init('kw8sds/youtube-zozss');</script>
+    <script src="renderer.js"></script>
 
     <style>
         body {
@@ -94,6 +95,24 @@
         .nav-link-custom:hover {
             text-decoration: underline;
         }
+        .navbar {
+            background-color: #0f0f0f !important;
+            border-bottom: 1px solid #272727;
+        }
+        .search-container {
+            max-width: 600px;
+        }
+        .form-control {
+            background-color: #121212;
+            border: 1px solid #333;
+            color: white;
+        }
+        .form-control:focus {
+            background-color: #121212;
+            border-color: #1a73e8;
+            color: white;
+            box-shadow: none;
+        }
         /* Custom Plyr Colors */
         :root {
             --plyr-color-main: #ff0000;
@@ -101,14 +120,21 @@
     </style>
 </head>
 <body>
-    <nav class="navbar navbar-dark bg-dark mb-4">
+    <nav class="navbar navbar-expand-lg navbar-dark sticky-top mb-4">
         <div class="container-fluid">
-            <a class="navbar-brand" href="/">
-                <img src="https://www.youtube.com/s/desktop/2823798a/img/favicon_32x32.png" width="30" height="30" class="d-inline-block align-top" alt="">
-                YouTube Downloader
+            <a class="navbar-brand d-flex align-items-center" href="/">
+                <img src="https://www.youtube.com/s/desktop/2823798a/img/favicon_32x32.png" width="30" height="30" class="me-2" alt="">
+                <strong>YouTube Downloader</strong>
             </a>
+            
+            <div class="d-flex flex-grow-1 justify-content-center mx-4">
+                <form id="commandForm" class="d-flex w-100 search-container m-0">
+                    <input class="form-control me-2 rounded-pill ps-4" type="text" id="commandInput" placeholder="Coller une URL YouTube..." required>
+                    <button class="btn btn-outline-light rounded-pill px-4" type="submit">Télécharger</button>
+                </form>
+            </div>
             <div class="d-flex">
-                <a href="/history" class="btn btn-outline-info btn-sm rounded-pill px-4">Historique</a>
+                <a href="/history" class="btn btn-outline-info rounded-pill px-4">Historique</a>
             </div>
         </div>
     </nav>
@@ -200,6 +226,18 @@
 
             // Exposé pour le debug si besoin
             window.player = player;
+        });
+
+        // Le téléchargement est géré par renderer.js via IPC.
+        // On peut ajouter un fallback au cas où renderer.js ne se charge pas correctement.
+        const commandForm = document.getElementById('commandForm');
+        commandForm.addEventListener('submit', (e) => {
+            // Si window.electronAPI n'existe pas, on utilise la route Express classique
+            if (!window.electronAPI) {
+                e.preventDefault();
+                const url = document.getElementById('commandInput').value;
+                window.location.href = `/download?url=${encodeURIComponent(url)}`;
+            }
         });
     </script>
 


### PR DESCRIPTION
Ajout de la barre de téléchargement de vidéo dans la vue de lecture, incrémentation de la version et mise à jour du journal des modifications.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a centered download form to the view page so users can paste a URL and download without leaving playback. It’s wired to Electron via renderer.js with an Express fallback, updates the navbar (sticky, dark), and bumps to 1.1.45 with a changelog entry.

<sup>Written for commit b6651004d82b0719483ea852985824e08cf699f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

