### PR TITLE
Potential fix for code scanning alert no. 34: Code injection

### DIFF
--- a/src/views/view.ejs
+++ b/src/views/view.ejs
@@ -176,7 +176,7 @@
                         <strong><a href="/channel?name=<%= (typeof videodata !== 'undefined' && videodata.uploader) ? encodeURIComponent(videodata.uploader) : '' %>" style="color: #ffffff; text-decoration: none;"><%= (typeof videodata !== 'undefined' && videodata.uploader) ? videodata.uploader : 'Uploader inconnu' %></a></strong> • <%= (typeof videodata !== 'undefined' && videodata.view_count) ? videodata.view_count.toLocaleString() + ' vues' : '' %>
                     </div>
                     <div class="d-flex align-items-center">
-                        <button id="favoriteBtn" class="btn <%= isFavorite ? 'btn-danger' : 'btn-outline-danger' %> btn-sm me-2" onclick='toggleFavorite(<%- JSON.stringify(code) %>)'>
+                        <button id="favoriteBtn" class="btn <%= isFavorite ? 'btn-danger' : 'btn-outline-danger' %> btn-sm me-2" onclick="toggleFavorite(<%- JSON.stringify(code).replace(/\"/g, '&quot;') %>)">
                             <%= isFavorite ? '❤' : '♡' %> Favori
                         </button>
                         <button class="btn btn-outline-success btn-sm me-2" onclick='addToQueue(<%- JSON.stringify(code) %>)'>File d'attente</button>


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/youtube-public/security/code-scanning/34](https://github.com/thomas-iniguez-visioli/youtube-public/security/code-scanning/34)

At a high level, the problem is that the untrusted `code` value is interpolated directly into an inline JavaScript context (`onclick="toggleFavorite('<%= code %>')"` and `onclick="addToQueue('<%= code %>')"`), and into several URLs (`/video/?id=`, `/delete?id=`, hidden `videoId` inputs). EJS’ default HTML escaping does not make the value safe for use inside JavaScript string literals, so a malicious value containing quotes can break out and inject code. The fix is to ensure that any untrusted value used in JavaScript is safely encoded for JavaScript, and any untrusted value in URLs is URL‑encoded.

The single best fix here, without changing existing functionality or adding new dependencies, is:

- For URL parameters and form hidden fields, wrap `code` with `encodeURIComponent(...)` right in the EJS expression, so the value is safe within URLs.
- For the inline JavaScript handlers, avoid placing raw `code` inside a quoted JavaScript string. The simplest and most robust approach in EJS is to JSON‑encode the value: `onclick='toggleFavorite(<%- JSON.stringify(code) %>)'`. `JSON.stringify` produces a properly quoted and escaped JavaScript string literal; using `<%-` (unescaped output) is correct here because `JSON.stringify` already ensures a safe JavaScript representation and we want that literal injected directly.
- Keep the existing semantics: the handlers still receive the same string value, and all routes and hidden inputs still receive the same `code` logically, but properly encoded.

Concretely, in `src/views/view.ejs`:

- Line 168: change `<source src="/video/?id=<%= code %>" ...>` to use `encodeURIComponent(code)`.
- Line 179: change `onclick="toggleFavorite('<%= code %>')"` so that the handler argument is a JSON string literal: `onclick='toggleFavorite(<%- JSON.stringify(code) %>)'`.
- Line 182: similarly change `onclick="addToQueue('<%= code %>')"` to use `JSON.stringify`.
- Line 192: change `<input type="hidden" name="videoId" value="<%= code %>">` to use `encodeURIComponent(code)`.
- Line 207: change `<a href="/delete?id=<%= code %>" ...>` to use `encodeURIComponent(code)`.
- Line 221: change `<input type="hidden" name="videoId" value="<%= code %>">` to use `encodeURIComponent(code)`.

No new imports are needed; `JSON` and `encodeURIComponent` are globally available in Node’s EJS rendering environment.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub code scanning alert #34 (code injection) by safely handling untrusted `code` in `src/views/view.ejs`. Blocks inline JS and URL injection without changing behavior.

- **Bug Fixes**
  - Video/links/inputs: use `encodeURIComponent(code)` for the player source, delete URL, and hidden `videoId`.
  - Inline handlers: use `JSON.stringify(code)`; escape quotes for `toggleFavorite` in a double-quoted attribute with `.replace(/\"/g, '&quot;')`, and use a single-quoted attribute for `addToQueue`.

<sup>Written for commit 128522a73f34726b19c01198aba66ae7eae08627. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

