### PR TITLE
Potential fix for code scanning alert no. 43: Incomplete string escaping or encoding

### DIFF
--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -318,12 +318,12 @@
             <div class="filter-chip active" onclick="filterByTag('all', this)">Tous</div>
             <% if (typeof allTags !== 'undefined') { %>
                 <% allTags.forEach(function(tag){ %>
-                    <div class="filter-chip" onclick="filterByTag('<%= tag.replace(/'/g, "\\'") %>', this)"><%= tag %></div>
+                    <div class="filter-chip" onclick="filterByTag('<%= tag.replace(/\\/g, "\\\\").replace(/'/g, "\\'") %>', this)"><%= tag %></div>
                 <% }); %>
             <% } %>
             <% if (typeof allChannels !== 'undefined') { %>
                 <% allChannels.forEach(function(uploader){ %>
-                    <div class="filter-chip" onclick="filterByChannel('<%= uploader.replace(/'/g, "\\'") %>', this)"><%= uploader %></div>
+                    <div class="filter-chip" onclick="filterByChannel('<%= uploader.replace(/\\/g, "\\\\").replace(/'/g, "\\'") %>', this)"><%= uploader %></div>
                 <% }); %>
             <% } %>
         </div>


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/youtube-public/security/code-scanning/43](https://github.com/thomas-iniguez-visioli/youtube-public/security/code-scanning/43)

In general, the right way to fix this is to stop doing ad‑hoc `.replace` escaping and instead use a proper JavaScript string serializer (or at least escape both backslashes and quotes) before embedding untrusted values into JavaScript string literals. For inline `onclick` handlers, we want the EJS output to be valid HTML and the embedded value to be a correctly escaped JavaScript string.

The minimal, non‑breaking fix in this file is to ensure that backslashes are escaped before single quotes when preparing the value for the `onclick` attribute. This preserves current behavior (values are still passed to `filterByTag` / `filterByChannel` as strings) but makes the escaping robust: every backslash becomes `\\` and every single quote becomes `\'`, so no extra string terminators can be injected.

Concretely, in `src/views/index.ejs`, lines 321 and 326 should be updated. Instead of only calling `.replace(/'/g, "\\'")`, we should first escape backslashes with `.replace(/\\/g, "\\\\")` and then escape single quotes. Because this is executed server‑side by Node’s EJS renderer, we can freely use JavaScript string/regex literals there. No new imports are necessary: we rely solely on built‑in `String.prototype.replace`.

So, for each place where we currently have:

```ejs
<%= tag.replace(/'/g, "\\'") %>
```

and

```ejs
<%= uploader.replace(/'/g, "\\'") %>
```

we replace them with:

```ejs
<%= tag.replace(/\\/g, "\\\\").replace(/'/g, "\\'") %>
```

and

```ejs
<%= uploader.replace(/\\/g, "\\\\").replace(/'/g, "\\'") %>
```

respectively. This keeps functionality identical while ensuring complete escaping for this use case.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape backslashes and single quotes for tag/uploader chips in `src/views/index.ejs` to generate safe inline `onclick` handlers. Fixes GitHub code scanning alert #43 for incomplete string escaping.

- **Bug Fixes**
  - Replace `.replace(/'/g, "\\'")` with `.replace(/\\/g, "\\\\").replace(/'/g, "\\'")` for `tag` and `uploader` values.

<sup>Written for commit 23e2feeafb15c7e0503c1a573e0c526e5a430091. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

