### PR TITLE
Potential fix for code scanning alert no. 42: Incomplete string escaping or encoding

### DIFF
--- a/src/views/view.ejs
+++ b/src/views/view.ejs
@@ -313,7 +313,7 @@
                         </button>
                         <button class="btn btn-outline-success btn-sm me-2" onclick='addToQueue(<%- JSON.stringify(code) %>)'>File d'attente</button>
                         <% if (typeof videodata !== 'undefined' && (videodata.channel_url || videodata.uploader_url)) { %>
-                            <button class="btn btn-outline-primary btn-sm me-2" onclick="downloadChannel('<%= (videodata.channel_url || videodata.uploader_url).replace(/'/g, "\\'") %>')">
+                            <button class="btn btn-outline-primary btn-sm me-2" onclick="downloadChannel(<%- JSON.stringify(videodata.channel_url || videodata.uploader_url) %>)">
                                 📥 Télécharger la chaîne
                             </button>
                         <% } %>


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/youtube-public/security/code-scanning/42](https://github.com/thomas-iniguez-visioli/youtube-public/security/code-scanning/42)

Use context-correct encoding for JavaScript string arguments in inline handlers: replace manual `.replace(/'/g, "\\'")` escaping with `JSON.stringify(...)`. `JSON.stringify` correctly escapes backslashes, quotes, and control characters for JavaScript string literal syntax.

Best single fix in `src/views/view.ejs`:
- Update line 316 region (`downloadChannel(...)`) to pass a JSON-serialized string directly:
  - From: `downloadChannel('<%= (videodata.channel_url || videodata.uploader_url).replace(/'/g, "\\'") %>')`
  - To: `downloadChannel(<%- JSON.stringify(videodata.channel_url || videodata.uploader_url) %>)`

No imports or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes code scanning alert 42 by safely encoding the channel URL in the inline JS handler. Replaces manual quote escaping with JSON.stringify in src/views/view.ejs so quotes, backslashes, and control characters are escaped correctly.

<sup>Written for commit 1f94fa29f4b16cff495be3affb8db5d31a681fb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

