### PR TITLE
Migration vers ESM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
           environment: 'production',
           captureUncaught: true,
           captureUnhandledRejections: true,
-           };" > rollbar.config.js
+           };" > rollbar.config.cjs
 
       - name: Build Electron app
         uses: samuelmeuli/action-electron-builder@v1

--- a/.github/workflows/test-and-report.yml
+++ b/.github/workflows/test-and-report.yml
@@ -31,25 +31,39 @@ jobs:
           repository: alphaleadership/kanbanaction
           ref: master
           path: .kanban-action
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: '20'
-          cache: 'npm'
+          bun-version: latest
+
       - name: Install dependencies
-        run: npm ci
+        run: bun install
+
+      - name: Setup Rollbar config (Mock)
+        run: |
+         echo "module.exports = {
+               accessToken: 'mock',
+               environment: 'test',
+               captureUncaught: false,
+               captureUnhandledRejections: false,
+           };" > rollbar.config.cjs
+
       - name: Install action dependencies
         run: npm ci
         working-directory: .kanban-action
+        
       - name: Log Workflow Type
         run: echo "Running workflow of type ${{ github.event.inputs.type || 'CI' }}"
+      
       - name: Run Tests
-        run: npm test -- --json --outputFile=test-results.json || true
+        run: bun test ./tests/*.test.js --reporter=junit > test-results.xml || true
+      
       - name: Report Failures
         if: always()
         working-directory: .kanban-action
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          TEST_RESULTS_PATH: ../test-results.json
+          TEST_RESULTS_PATH: ../test-results.xml
         run: node scripts/report-test-failures.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 node_modules/*
 client-dist/*
 nextgen/my-electron-app/*.mp4*
@@ -10,4 +9,4 @@ nextgen/my-electron-app/dist/youtube Setup 1.0.0.exe.blockmap
 dist/*
 test-logrocket.js
 rollbar.config.js
-
+rollbar.config.cjs

--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,11 @@
       "name": "youtube",
       "dependencies": {
         "axios": "^1.7.9",
+        "cors": "^2.8.6",
         "ejs": "^3.1.10",
         "electron-log": "^5.2.4",
         "electron-updater": "^6.3.9",
+        "escape-html": "^1.0.3",
         "express": "^4.21.1",
         "express-rate-limit": "^7.5.0",
         "helmet": "^8.1.0",
@@ -19,7 +21,7 @@
         "uuid": "^11.0.3",
       },
       "devDependencies": {
-        "electron": "^34.0.0",
+        "electron": "^41.0.3",
         "electron-builder": "^25.1.8",
         "typescript": "^5.0.0",
       },
@@ -80,7 +82,7 @@
 
     "@types/ms": ["@types/ms@0.7.34", "", {}, "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="],
 
-    "@types/node": ["@types/node@20.17.13", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-RNf+4dEeV69PIvyp++4IKM2vnLXtmp/JovfeQm5P5+qpKb6wHoH7INywLdZ7z+gVX46kgBP/fwJJvZYaHxtdyw=="],
+    "@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "@types/plist": ["@types/plist@3.0.5", "", { "dependencies": { "@types/node": "*", "xmlbuilder": ">=11.0.1" } }, "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA=="],
 
@@ -236,7 +238,7 @@
 
     "core-util-is": ["core-util-is@1.0.2", "", {}, "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="],
 
-    "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "crc": ["crc@3.8.0", "", { "dependencies": { "buffer": "^5.1.0" } }, "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ=="],
 
@@ -290,7 +292,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": "bin/cli.js" }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron": ["electron@34.0.0", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^20.9.0", "extract-zip": "^2.0.1" }, "bin": "cli.js" }, "sha512-fpaPb0lifoUJ6UJa4Lk8/0B2Ku/xDZWdc1Gkj67jbygTCrvSon0qquju6Ltx1Kz23GRqqlIHXiy9EvrjpY7/Wg=="],
+    "electron": ["electron@41.5.0", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-x9j9//PubUA4EjDtQbZhtk3prolandqCKgit0uCIqc1jb8FTskPbnJtxcDFB1aejczJcuERgjPixBUaMwoWyJg=="],
 
     "electron-builder": ["electron-builder@25.1.8", "", { "dependencies": { "app-builder-lib": "25.1.8", "builder-util": "25.1.7", "builder-util-runtime": "9.2.10", "chalk": "^4.1.2", "dmg-builder": "25.1.8", "fs-extra": "^10.1.0", "is-ci": "^3.0.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig=="],
 
@@ -768,7 +770,7 @@
 
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
-    "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unique-filename": ["unique-filename@2.0.1", "", { "dependencies": { "unique-slug": "^3.0.0" } }, "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A=="],
 
@@ -840,13 +842,9 @@
 
     "@electron/osx-sign/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
-    "@electron/osx-sign/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
-
     "@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
 
     "@electron/rebuild/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
-
-    "@electron/rebuild/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
     "@electron/universal/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
@@ -880,13 +878,9 @@
 
     "app-builder-lib/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
-    "app-builder-lib/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
-
     "archiver/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "archiver-utils/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
-    "archiver-utils/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "are-we-there-yet/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -894,13 +888,9 @@
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
     "body-parser/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "builder-util/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
-
-    "builder-util/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
     "builder-util-runtime/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
@@ -918,27 +908,19 @@
 
     "dir-compare/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
-    "dmg-builder/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
-
-    "electron-builder-squirrel-windows/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
-
-    "electron-publish/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
-
     "electron-publish/mime": ["mime@2.6.0", "", { "bin": "cli.js" }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
-
-    "electron-updater/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
     "engine.io/@types/node": ["@types/node@22.10.6", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ=="],
 
     "engine.io/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "engine.io/cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
     "engine.io/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
 
     "extract-zip/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
-
-    "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
@@ -957,8 +939,6 @@
     "humanize-ms/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "jake/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
-
-    "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "make-fetch-happen/http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
 
@@ -980,8 +960,6 @@
 
     "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
-    "morgan/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
     "morgan/on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
 
     "node-gyp/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -1002,11 +980,11 @@
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
-    "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
     "send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
 
     "send/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "socket.io/cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
     "socket.io/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
 
@@ -1028,15 +1006,11 @@
 
     "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "temp-file/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
-
     "unzipper/fs-extra": ["fs-extra@11.3.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew=="],
 
     "zip-stream/archiver-utils": ["archiver-utils@3.0.4", "", { "dependencies": { "glob": "^7.2.3", "graceful-fs": "^4.2.0", "lazystream": "^1.0.0", "lodash.defaults": "^4.2.0", "lodash.difference": "^4.5.0", "lodash.flatten": "^4.4.0", "lodash.isplainobject": "^4.0.6", "lodash.union": "^4.6.0", "normalize-path": "^3.0.0", "readable-stream": "^3.6.0" } }, "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw=="],
 
     "zip-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
-    "@electron/asar/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "@electron/asar/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 
@@ -1048,27 +1022,11 @@
 
     "@electron/notarize/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "@electron/notarize/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "@electron/notarize/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
     "@electron/osx-sign/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "@electron/osx-sign/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "@electron/osx-sign/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "@electron/rebuild/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "@electron/rebuild/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "@electron/rebuild/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
     "@electron/universal/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "@electron/universal/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "@electron/universal/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -1077,10 +1035,6 @@
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "@malept/flatpak-bundler/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "@malept/flatpak-bundler/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "@malept/flatpak-bundler/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "@types/cacheable-request/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
@@ -1098,15 +1052,7 @@
 
     "app-builder-lib/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "app-builder-lib/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "app-builder-lib/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
     "archiver-utils/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
-
-    "archiver-utils/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
-    "archiver-utils/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "archiver/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
@@ -1114,15 +1060,9 @@
 
     "bl/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
     "builder-util-runtime/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "builder-util/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "builder-util/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "builder-util/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "cacache/glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
@@ -1132,39 +1072,17 @@
 
     "dir-compare/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 
-    "dmg-builder/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "dmg-builder/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
-    "electron-builder-squirrel-windows/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "electron-builder-squirrel-windows/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
-    "electron-publish/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "electron-publish/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
-    "electron-updater/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "electron-updater/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
     "engine.io/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
     "engine.io/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "extract-zip/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
     "http-proxy-agent/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "https-proxy-agent/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "jake/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
-
-    "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
-    "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "make-fetch-happen/http-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
@@ -1174,15 +1092,11 @@
 
     "make-fetch-happen/https-proxy-agent/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
-    "morgan/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
     "node-gyp/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "read-binary-file-arch/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "rimraf/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
-
-    "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "socket.io-adapter/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -1196,19 +1110,9 @@
 
     "tar-stream/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "temp-file/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "temp-file/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
-    "unzipper/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
-
-    "unzipper/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
     "zip-stream/archiver-utils/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "zip-stream/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
-
-    "@electron/asar/glob/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 
     "archiver-utils/glob/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 

--- a/index.js
+++ b/index.js
@@ -1,173 +1,51 @@
-const web = require('express')();
-const express=require("express")
-const fs=require("fs")
-const http = require('http').Server(web);
-const io = require('socket.io')(http);
-const rateLimit = require('express-rate-limit');
+import express from 'express';
+const web = express();
+import fs from 'fs';
+import { createServer } from 'http';
+import { Server as SocketServer } from 'socket.io';
+import RateLimit from 'express-rate-limit';
+import FileDatabase from './src/db.js';
+import path from 'path';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import https from 'https';
+import cors from 'cors';
 
-const d=require("./src/db.js")
-const path = require('path');
-const { app } = require('electron');
+const require = createRequire(import.meta.url);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+let app;
+try {
+  app = require('electron').app;
+} catch (e) {}
+
+const httpServer = createServer(web);
+const io = new SocketServer(httpServer);
+
 let backlogFile = './backlog.txt';
 try {
   if (app) backlogFile = path.join(app.getPath('desktop'), 'backlog.txt');
 } catch (e) {}
 const base ="./video"
-const db=new d(base)
+const db = new FileDatabase(base);
 web.locals.backlogFile = backlogFile;
 
-const limiter = rateLimit({
+const limiter = RateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 100 // limit each IP to 100 requests per windowMs
 });
 web.use(limiter);
 
-function build() {
-  get("https://cdn.socket.io/4.4.1/socket.io.js","./client-dist/socket.io.js")
-  .then( ()=> console.log('downloaded file no issues...'))
-  .catch( e => console.error('error while downloading', e));
-  get("https://cdn.socket.io/4.4.1/socket.io.js.map","./client-dist/socket.io.js.map").then( ()=> console.log('downloaded file no issues...'))
-  .catch( e => console.error('error while downloading', e));
-  get("https://github.com/yt-dlp/yt-dlp/releases/download/2023.02.17/yt-dlp.exe","ytdlp.exe").then(()=> console.log('downloaded file no issues...'))  .catch( e => console.error('error while downloading', e));
-  try {
-    fs.mkdirSync("./views")
-    fs.mkdirSync("./log")
-    fs.mkdirSync(base)
-   
-  } catch (error) {
-    console.log(error)
-  }
-}
-try {
-
-} catch (error) {
-  console.log(error)
-}
-if(!fs.existsSync("./client-dist")){fs.mkdirSync("./client-dist")
-build()}
-
-const socketpath =()=>{
-
-    return "./client-dist"
-}
-
-
-const morgan = require('morgan');
-const accessLogStream=fs.createWriteStream("./log/access-"+`${new Date().toDateString()}`+".log")
-const errorLogStream=fs.createWriteStream("./log/error"+`${new Date().toDateString()}`+".log")
-web.use(morgan('combined', {stream: accessLogStream}));
-web.use(morgan('combined', {skip: function (req, res) { return res.statusCode < 400 }, stream: errorLogStream}));
-db.readDatabase()
-db.save()
-db.database.map((item)=>{item.yid})
-web.set('view engine', 'ejs');
-web.get("/", function (req, res) {
-
-  res.render('index', {
-    results: db.database
-    
-});
-})
-web.get("/search", function (req, res) {
-  console.log(db.search(req.query.substring))
-  res.render('index', {
-    results: db.search(req.query.substring)
-    
-});
-})
-web.get("/watch", function (req, res) {
-  console.log(req.query)
-  res.render('view', {
-    code: req.query.id,
-    title:db.getFile( req.query.id).fileName
-   
-    
-});
-});
-web.get("/video", function (req, res) {
-  // Chargez les données de la base de données à partir du fichier
-
-
-  // Trouvez l'entrée de session de vidéo correspondante
-  let startTime = 0;
-  let endTime = 0;
- 
-
-  // Si l'heure de fin est définie, utilisez-la comme point de départ pour l'en-tête Range
-  // sinon, utilisez l'heure de début comme point de départ
-  let rangeStart = 0;
-  if (endTime) {
-    rangeStart = endTime;
-  } else {
-    rangeStart = startTime;
-  }
-
-  // Ensure there is a range given for the video
-  const range = req.headers.range;
-  if (!range) {
-    res.status(400).send("Requires Range header");
-  }
-
-  const videoPath =base+ db.getFile( req.query.id).fileName
-  console.log(videoPath)
-  console.log()
-  const videoSize = fs.statSync(videoPath).size;
-
-  const CHUNK_SIZE = 10 ** 6; // 1MB
-  const start = Number(range.replace(/\D/g, ""));
-  const end = Math.min(start + CHUNK_SIZE, videoSize - 1);
-
-  // Create headers
-  const contentLength = end - start + 1;
-  const headers = {
-    "Content-Range": `bytes ${start}-${end}/${videoSize}`,
-    "Accept-Ranges": "bytes",
-    "Content-Length": contentLength,
-    "Content-Type": "video/mp4",
-  };
-
-  // HTTP Status 206 for Partial Content
-  res.writeHead(206, headers);
-
-  // Create a new entry in the database for this video session
-
-
-  // Enregistrez les données mises à jour dans le fichier
-  
-  
-  // create video read stream for this particular chunk
-  const videoStream = fs.createReadStream(videoPath, { start, end });
-
-  // Stream the video chunk to the client
-  videoStream.pipe(res);
-
-  // When the stream ends, save the end time in the database
-  videoStream.on("end", () => {
-    // Chargez à nouveau les données de la base de données à partir du fichier
-    
-
-    // Enregistrez les données mises à jour dans le fichier
-  
-  });
-});
-
-web.listen(8000, function () {
-  console.log("Listening on port 8000!");
-});
-
-const download=require("./nextgen/my-electron-app/src/ytb.js")
-const https=require("https")
-console.log("boot now")
 function get(url, dest) {
   return new Promise((resolve, reject) => {
     // Check file does not exist yet before hitting network
     fs.access(dest, fs.constants.F_OK, (err) => {
-
         if (err === null) reject('File already exists');
 
         const request = https.get(url, response => {
             if (response.statusCode === 200) {
-       
               const file = fs.createWriteStream(dest, { flags: 'wx' });
               file.on('finish', () => resolve());
               file.on('error', err => {
@@ -190,72 +68,143 @@ function get(url, dest) {
     });
   });
 }
-var cors = require('cors')
 
-  
-  web.use(cors())
-
-
- 
-// or
-const down=(input)=>{
-      // Exemple d'une chaîne de caractères
-      var str = input
-    
-      // Vérifie si la sous-chaîne existe dans la chaîne de caractères
-      var playlist = str.indexOf("https://www.youtube.com/playlist?list=");
-      var video = str.indexOf("https://www.youtube.com/watch?v="); 
-      console.log(`playlist type =${playlist} \n video type =${video}`)    
-      if(playlist !== -1){
-          download.main(str,function log(string) {
-	db.readDatabase()
-db.save()
-            io.emit('chat message', string);
-          })
-
-
-      } else{
-        if (video!==-1) {
-          id =input.split("=")[1]
-          download.id(id,function log(string) {
-db.readDatabase()
-db.save()
-            console.log(string); io.emit('chat message', string);
-          })
-        } else {
-          download.main(input,function log(string) {
-            io.emit('chat message', string);
-          })
-        }
-        
-      }
-  
+function build() {
+  get("https://cdn.socket.io/4.4.1/socket.io.js","./client-dist/socket.io.js")
+  .then( ()=> console.log('downloaded file no issues...'))
+  .catch( e => console.error('error while downloading', e));
+  get("https://cdn.socket.io/4.4.1/socket.io.js.map","./client-dist/socket.io.js.map").then( ()=> console.log('downloaded file no issues...'))
+  .catch( e => console.error('error while downloading', e));
+  get("https://github.com/yt-dlp/yt-dlp/releases/download/2023.02.17/yt-dlp.exe","ytdlp.exe").then(()=> console.log('downloaded file no issues...'))  .catch( e => console.error('error while downloading', e));
+  try {
+    if (!fs.existsSync("./views")) fs.mkdirSync("./views");
+    if (!fs.existsSync("./log")) fs.mkdirSync("./log");
+    if (!fs.existsSync(base)) fs.mkdirSync(base);
+  } catch (error) {
+    console.log(error);
+  }
 }
+
+if(!fs.existsSync("./client-dist")){
+    fs.mkdirSync("./client-dist");
+    build();
+}
+
+const socketpath = () => {
+    return "./client-dist";
+}
+
+import morgan from 'morgan';
+const accessLogStream = fs.createWriteStream("./log/access-" + `${new Date().toDateString()}` + ".log");
+const errorLogStream = fs.createWriteStream("./log/error" + `${new Date().toDateString()}` + ".log");
+web.use(morgan('combined', {stream: accessLogStream}));
+web.use(morgan('combined', {skip: function (req, res) { return res.statusCode < 400 }, stream: errorLogStream}));
+
+db.readDatabase();
+db.save();
+
+web.set('view engine', 'ejs');
+web.get("/", function (req, res) {
+  res.render('index', {
+    results: db.database
+  });
+});
+
+web.get("/search", function (req, res) {
+  res.render('index', {
+    results: db.search(req.query.substring)
+  });
+});
+
+web.get("/watch", function (req, res) {
+  res.render('view', {
+    code: req.query.id,
+    title: db.getFile(req.query.id).fileName
+  });
+});
+
+web.get("/video", function (req, res) {
+  const range = req.headers.range;
+  if (!range) {
+    return res.status(400).send("Requires Range header");
+  }
+
+  const videoPath = base + db.getFile(req.query.id).fileName;
+  const videoSize = fs.statSync(videoPath).size;
+
+  const CHUNK_SIZE = 10 ** 6; // 1MB
+  const start = Number(range.replace(/\D/g, ""));
+  const end = Math.min(start + CHUNK_SIZE, videoSize - 1);
+
+  const contentLength = end - start + 1;
+  const headers = {
+    "Content-Range": `bytes ${start}-${end}/${videoSize}`,
+    "Accept-Ranges": "bytes",
+    "Content-Length": contentLength,
+    "Content-Type": "video/mp4",
+  };
+
+  res.writeHead(206, headers);
+  const videoStream = fs.createReadStream(videoPath, { start, end });
+  videoStream.pipe(res);
+});
+
+// Note: ytb.js path might be incorrect if it was legacy
+let downloadModule;
+try {
+    downloadModule = (await import("./src/ytb.js")).default;
+} catch (e) {
+    console.warn("Could not load ytb module from src/ytb.js");
+}
+
+web.use(cors());
+
+const down = (input) => {
+    var str = input;
+    var playlist = str.indexOf("https://www.youtube.com/playlist?list=");
+    var video = str.indexOf("https://www.youtube.com/watch?v="); 
+    
+    if (!downloadModule) return;
+
+    if(playlist !== -1){
+        downloadModule.main(str, function log(string) {
+            db.readDatabase();
+            db.save();
+            io.emit('chat message', string);
+        });
+    } else {
+        if (video !== -1) {
+            const id = input.split("=")[1];
+            downloadModule.id(id, function log(string) {
+                db.readDatabase();
+                db.save();
+                io.emit('chat message', string);
+            });
+        } else {
+            downloadModule.main(input, function log(string) {
+                io.emit('chat message', string);
+            });
+        }
+    }
+}
+
 const port = process.env.PORT || 3040;
-
-
-web.use(express.static(socketpath()))
-
+web.use(express.static(socketpath()));
 
 io.on('connection', (socket) => {
-  io.emit('chat message', download.path+" est le chemin ou sont les fichier entrée  le lien  ")
+  io.emit('chat message', (downloadModule ? downloadModule.path : "./video") + " est le chemin ou sont les fichier entrée le lien ");
   socket.on('chat message', msg => {
-    //console.log(msg)
-    down(msg,io)
+    down(msg);
     io.emit('chat message', msg);
   });
 });
 
-
-const { app, BrowserWindow } = require('electron')
-console.log(app)
-const path = require('path')
+const { BrowserWindow } = require('electron');
 
 function createWindow () {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
-    
     webPreferences: {
       preload: path.join(__dirname, 'preload.js')
     }
@@ -264,21 +213,19 @@ function createWindow () {
   win.loadURL("http://localhost:"+port)
 }
 
-
-http.listen(port, () => {
+httpServer.listen(port, () => {
   console.log(`Socket.IO server running at http://localhost:${port}/`);
+  if (app) {
     app.whenReady().then(() => {
-      createWindow()
-  
-     app.on('activate', () => {
-       if (BrowserWindow.getAllWindows().length === 0) {
-         createWindow()
-       }else{createWindow()}
-     })
-     app.on('window-all-closed', () => {
-      if (process.platform !== 'darwin') {
-      app.quit()
-     }
-    })
-   })
+      createWindow();
+      app.on('activate', () => {
+        if (BrowserWindow.getAllWindows().length === 0) {
+          createWindow();
+        }
+      });
+      app.on('window-all-closed', () => {
+        if (process.platform !== 'darwin') app.quit();
+      });
+    });
+  }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "youtube",
   "version": "1.6.1",
+  "type": "module",
   "description": "youtube local",
   "main": "src/index.js",
   "private": true,
@@ -12,9 +13,11 @@
   },
   "dependencies": {
     "axios": "^1.7.9",
+    "cors": "^2.8.6",
     "ejs": "^3.1.10",
     "electron-log": "^5.2.4",
     "electron-updater": "^6.3.9",
+    "escape-html": "^1.0.3",
     "express": "^4.21.1",
     "express-rate-limit": "^7.5.0",
     "helmet": "^8.1.0",
@@ -22,8 +25,7 @@
     "rollbar": "^2.26.5",
     "socket.io": "^4.4.1",
     "unzipper": "^0.12.3",
-    "uuid": "^11.0.3",
-    "escape-html": "^1.0.3"
+    "uuid": "^11.0.3"
   },
   "devDependencies": {
     "electron": "^41.0.3",

--- a/src/autoupdate.js
+++ b/src/autoupdate.js
@@ -1,10 +1,20 @@
-const { app, autoUpdater, dialog } = require('electron');
-const os = require('os');
-const path = require('path');
-const url = require('url');
-const fs = require('fs');
-const https = require('https');
-const AdmZip = require('adm-zip');
+import { app, autoUpdater, dialog } from 'electron';
+import os from 'os';
+import path from 'path';
+import url from 'url';
+import fs from 'fs';
+import https from 'https';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+// AdmZip is likely a dependency that needs to be imported, but if it's not in package.json
+// it might fail. I'll use require for it for now if it's actually there.
+let AdmZip;
+try {
+  AdmZip = require('adm-zip');
+} catch (e) {
+  console.warn('adm-zip not found, portable updates might fail');
+}
 
 let updateFeed = 'https://your-update-server.com/update';
 let isPortable = false;
@@ -16,7 +26,7 @@ if (fs.existsSync(path.join(app.getPath('exe'), '..', 'portable.txt'))) {
 autoUpdater.setFeedURL(updateFeed);
 
 autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
-  if (isPortable) {
+  if (isPortable && AdmZip) {
     const zip = new AdmZip(event.path);
     zip.extractAllTo(path.join(app.getPath('exe'), '..'), true);
   } else {
@@ -42,12 +52,5 @@ app.on('ready', () => {
   autoUpdater.checkForUpdates();
 });
 
-
-
 console.log(autoUpdater);
-module.exports=autoUpdater
-/*! Bundled license information:
-
-sax/lib/sax.js:
-  (*! http://mths.be/fromcodepoint v0.1.0 by @mathias *)
-*/
+export default autoUpdater;

--- a/src/autoupdate.js
+++ b/src/autoupdate.js
@@ -1,9 +1,6 @@
 import { app, autoUpdater, dialog } from 'electron';
-import os from 'os';
 import path from 'path';
-import url from 'url';
 import fs from 'fs';
-import https from 'https';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);

--- a/src/binaryResolver.js
+++ b/src/binaryResolver.js
@@ -1,6 +1,10 @@
-const path = require('path');
-const fs = require('fs');
-const child_process = require('child_process');
+import path from 'path';
+import fs from 'fs';
+import child_process from 'child_process';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
 let app;
 try {
   app = require('electron').app;
@@ -9,7 +13,6 @@ try {
 }
 
 const isWin = process.platform === 'win32';
-console.log(isWin);
 const BINARIES = {
   ytdlp: isWin ? 'ytdlp.exe' : 'ytdlp',
   ffmpeg: isWin ? 'ffmpeg.exe' : 'ffmpeg',
@@ -87,4 +90,4 @@ const binaryResolver = {
   }
 };
 
-module.exports = binaryResolver;
+export default binaryResolver;

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,17 +1,23 @@
-const FileDatabase = require('../db');
-const path = require('path');
-const { app } = require('electron'); // Assuming electron app object is available
+import FileDatabase from '../db.js';
+import path from 'path';
+import { createRequire } from 'module';
 
-const userDataPath = app.getPath('userData');
+const require = createRequire(import.meta.url);
+
+let app;
+try {
+    app = require('electron').app;
+} catch (e) {}
+
+const userDataPath = app ? app.getPath('userData') : process.cwd();
 const fileDb = new FileDatabase(path.join(userDataPath, 'file'));
 
-
-exports.home = (req, res) => {
+export const home = (req, res) => {
     // This is a placeholder. In a real app, you'd render a view with video data.
     res.send('Welcome to the home page! Videos will be displayed here.');
 };
 
-exports.getVideo = (req, res) => {
+export const getVideo = (req, res) => {
     const videoId = req.params.id;
     const video = fileDb.getFile(videoId);
     if (video) {
@@ -21,12 +27,12 @@ exports.getVideo = (req, res) => {
     }
 };
 
-exports.uploadVideo = (req, res) => {
+export const uploadVideo = (req, res) => {
     // Placeholder for video upload logic
     res.status(200).send('Video upload initiated (placeholder).');
 };
 
-exports.addToQueue = (req, res) => {
+export const addToQueue = (req, res) => {
     const { videoId } = req.body;
     if (videoId && fileDb.getFile(videoId)) {
         fileDb.addToQueue(videoId);
@@ -36,7 +42,7 @@ exports.addToQueue = (req, res) => {
     }
 };
 
-exports.removeFromQueue = (req, res) => {
+export const removeFromQueue = (req, res) => {
     const { videoId } = req.body;
     if (videoId) {
         fileDb.removeFromQueue(videoId);
@@ -46,12 +52,12 @@ exports.removeFromQueue = (req, res) => {
     }
 };
 
-exports.getQueue = (req, res) => {
+export const getQueue = (req, res) => {
     const queue = fileDb.getQueue();
     res.status(200).json(queue);
 };
 
-exports.clearQueue = (req, res) => {
+export const clearQueue = (req, res) => {
     fileDb.clearQueue();
     res.status(200).send('Queue cleared.');
 };

--- a/src/db.js
+++ b/src/db.js
@@ -1,14 +1,21 @@
-let uuid = require("uuid")
-const fs = require("fs");
-const path = require("path");
+import fs from "fs";
+import path from "path";
+import { createRequire } from 'module';
 
-const app = require('electron').app;
-const userDataPath = app.getPath('userData');
+const require = createRequire(import.meta.url);
+
+let app;
+try {
+    app = require('electron').app;
+} catch (e) {
+    // Not in Electron
+}
+
+const userDataPath = app ? app.getPath('userData') : process.cwd();
 const databaseFilePath = path.join(userDataPath, 'database.json');
 const regex = /\[(.*?)\]/;
 
-module.exports =
-class FileDatabase {
+export default class FileDatabase {
     constructor(directoryPath) {
         this.directoryPath = directoryPath;
         this.database = [];
@@ -346,4 +353,3 @@ class FileDatabase {
         this.saveDatabase();
     }
 }
-

--- a/src/downloader.js
+++ b/src/downloader.js
@@ -1,15 +1,17 @@
-const child = require('child_process');
-const path = require('path');
-const fs = require('fs');
-const binval=require("./binaryResolver")
+import child from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import binval from "./binaryResolver.js";
+
 binval.validateBinaries().then((data)=>{
   console.log(data)
 })
 console.log(binval.ffmpeg)
+
 function getBrowserForCookies() {
   // Priorité Firefox, sinon Chrome
   // Sur Windows, on peut vérifier les chemins par défaut
-  const firefoxPath = path.join(process.env.APPDATA, 'Mozilla', 'Firefox', 'Profiles');
+  const firefoxPath = path.join(process.env.APPDATA || '', 'Mozilla', 'Firefox', 'Profiles');
   if (fs.existsSync(firefoxPath)) {
     return 'firefox';
   }
@@ -117,7 +119,7 @@ function createMetadataArgs(parameter, ffmpegDir, storagePath, outputFileFormat,
   return args;
 }
 
-module.exports = {
+export {
   createDownloadArgs,
   createMetadataArgs,
   runDownload

--- a/src/index.js
+++ b/src/index.js
@@ -1,31 +1,48 @@
-const { app, BrowserWindow, ipcMain, dialog, Menu, session } = require('electron');
-const binaryResolver = require('./binaryResolver');
-const rollbarConfig = require('../rollbar.config.js');
+import { app, BrowserWindow, ipcMain, dialog, Menu, session } from 'electron';
+import binaryResolver from './binaryResolver.js';
+import { createRequire } from 'module';
+import cors from 'cors';
+import express from 'express';
+import RateLimit from 'express-rate-limit';
+import fs from 'fs';
+import https from 'https';
+import escapeHtml from 'escape-html';
+import path from 'path';
+import os from 'os';
+import { updateFile } from './updater.js';
+import { createDownloadArgs, runDownload, createMetadataArgs } from './downloader.js';
+import FileDatabase from './db.js';
+import child from 'child_process';
+import log from 'electron-log';
+import morgan from 'morgan';
+import { Server as SocketServer } from 'socket.io';
+import { createServer } from 'http';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
+const rollbarConfig = require('../rollbar.config.cjs');
+log.info('Rollbar config loaded:', rollbarConfig ? 'Yes' : 'No');
 const Rollbar = require('rollbar');
-const rollbar =new Rollbar(rollbarConfig);
-const e=require("electron")
-const cors =require("cors")
-var booted=false
-const {autoUpdater}=require("electron-updater")//require("./autoupdate")
-const express = require('express');
-const RateLimit = require('express-rate-limit');
-const fs = require('fs');const https = require('https');
-const escapeHtml = require('escape-html');
-const path = require('path');
-const os = require('os');
-const { updateFile } = require('./updater');
-const { createDownloadArgs, runDownload, createMetadataArgs } = require('./downloader');
-const FileDatabase = require('./db');
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const rollbar = new Rollbar(rollbarConfig);
+var booted = false;
+const { autoUpdater } = require("electron-updater");
+
 const base = path.join(app.getPath('userData'), 'file');
 const db = new FileDatabase(base);
+
 // Deferred sync to avoid blocking startup
 setTimeout(() => {
   db.readDatabase();
   db.save();
 }, 1000);
+
 const web = express();
-const child = require('child_process');
-const log = require('electron-log');
 log.transports.file.level = 'debug';
 log.transports.console.level = 'debug';
 log.transports.file.file = path.join(app.getPath('userData'), 'log', 'app.log');
@@ -132,25 +149,28 @@ function setupElectronLogForwarding() {
         level: message.level,
         // Ajoute d'autres métadonnées pertinentes pour ton projet
         app: 'YouTube Downloader Extension',
-        version: require('../package.json').version,
+        version: pkg.version,
       },
     });
 
     return message;
   });
 }
-setupElectronLogForwarding()
-const getconfig=()=>{
-  if(fs.existsSync(path.join(app.getPath('userData'), 'config.json'))){
-    return require(path.join(app.getPath('userData'), 'config.json'));
+setupElectronLogForwarding();
+
+const getconfig = () => {
+  const configPath = path.join(app.getPath('userData'), 'config.json');
+  if (fs.existsSync(configPath)) {
+    return require(configPath);
   }
-  fs.writeFileSync(path.join(app.getPath('userData'), 'config.json'), JSON.stringify({
+  const defaultConfig = {
     "storagePath": path.join(app.getPath('userData'), 'file'),
     "videoUrlFormat": "https://www.youtube.com/watch?v=${id}",
     "outputFileFormat": "%(channel|)s-%(folder_name|)s-%(title)s [%(id)s].%(ext)s"
-  }))
-  return require(path.join(app.getPath('userData'), 'config.json'))
-}
+  };
+  fs.writeFileSync(configPath, JSON.stringify(defaultConfig));
+  return defaultConfig;
+};
 const config = getconfig();
 
 // Surveillance du dossier vidéo pour mise à jour automatique de la DB
@@ -198,15 +218,13 @@ const limiter = RateLimit({
   max: 100000, // Increased from 10000 to 100000
 });
 
-  
+if (!fs.existsSync(path.join(__dirname))) {
+  fs.mkdirSync(path.join(__dirname));
+}
+if (!fs.existsSync(path.join(app.getPath('userData'), "parsed.txt"))) {
+  fs.writeFileSync(path.join(app.getPath('userData'), "parsed.txt"), "");
+}
 
-if (!fs.existsSync(path.join(__dirname))) { // Correction pour utiliser path.join pour une construction de chemin valide
-  fs.mkdirSync(path.join(__dirname)) // Correction pour utiliser path.join pour une construction de chemin valide
-}
-if (!fs.existsSync(path.join(app.getPath('userData'), "parsed.txt"))) { // Correction pour utiliser path.join pour une construction de chemin valide
-  fs.writeFileSync(path.join(app.getPath('userData'), "parsed.txt"), "") // Correction pour utiliser path.join pour une construction de chemin valide
-}
-//autoUpdater.allowDowngrade=true
 function getRedirectedUrl(url) {
   return new Promise((resolve, reject) => {
     https.get(url, (res) => {
@@ -220,6 +238,7 @@ function getRedirectedUrl(url) {
     });
   });
 }
+
 // Move initial autoUpdater check to background or deferred
 const initAutoUpdater = () => {
   getRedirectedUrl("https://github.com/thomas-iniguez-visioli/youtube-public/releases/latest").then((url)=>{
@@ -236,10 +255,6 @@ setInterval(initAutoUpdater, 120000);
 // Run first check deferred
 setTimeout(initAutoUpdater, 5000);
 
-
-
-
-//log.info(autoUpdater)
 function extractUrls(text) {
   const urlRegex = /https?:\/\/(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/g;
   return text.match(urlRegex) || [];
@@ -247,13 +262,11 @@ function extractUrls(text) {
 let win;
 function sendStatusToWindow(text) {
   log.info(text);
-  //win.webContents.send('message', text);
 }
 autoUpdater.on('checking-for-update', () => {
   sendStatusToWindow('Checking for update...');
 })
 autoUpdater.on('update-available', (info) => {
-  
   sendStatusToWindow('Update available.');
 })
 autoUpdater.on('update-not-available', (info) => {
@@ -276,6 +289,7 @@ autoUpdater.on('update-downloaded', (info) => {
     autoUpdater.quitAndInstall();
   }, 3000);
 });
+
 let backlogFile = 'backlog.txt';
 try {
   backlogFile = path.join(app.getPath('desktop'), 'backlog.txt');
@@ -303,8 +317,6 @@ const loadBacklog = () => {
       const data = fs.readFileSync(backlogFile, 'utf8');
       const lines = data.split('\n').map(line => line.trim()).filter(line => line.length > 0);
       
-      // On remplace le contenu du backlog par celui du fichier, 
-      // tout en préservant l'ordre.
       backlog.length = 0;
       lines.forEach(line => {
         if (!backlog.includes(line)) {
@@ -350,8 +362,8 @@ const download = (url) => {
   }
 };
 
-const http = require('http').Server(web);
-const io = require('socket.io')(http);
+const httpServer = createServer(web);
+const io = new SocketServer(httpServer);
 
 // Forward errors to the UI via Socket.io
 log.hooks.push((message) => {
@@ -459,26 +471,23 @@ const processBacklog = async () => {
 
 setInterval(processBacklog, 1000);
 
-const morgan = require('morgan');
-const accessLogStream=fs.createWriteStream(path.join(app.getPath('userData'), "./log/access-"+`${new Date().toDateString()}`+".log"))
-const errorLogStream=fs.createWriteStream(path.join(app.getPath('userData'), "./log/error-"+`${new Date().toDateString()}`+".log"))
-web.use(morgan('combined', {stream: accessLogStream}));
-web.use(morgan('combined', {skip: function (req, res) { return res.statusCode < 400 }, stream: errorLogStream}));
+const accessLogStream = fs.createWriteStream(path.join(app.getPath('userData'), "./log/access-" + `${new Date().toDateString()}` + ".log"));
+const errorLogStream = fs.createWriteStream(path.join(app.getPath('userData'), "./log/error-" + `${new Date().toDateString()}` + ".log"));
+web.use(morgan('combined', { stream: accessLogStream }));
+web.use(morgan('combined', { skip: function (req, res) { return res.statusCode < 400 }, stream: errorLogStream }));
 
-// Middleware pour capturer les erreurs Express et les envoyer à LogRocket
+// Middleware pour capturer les erreurs Express
 web.use((err, req, res, next) => {
   log.error(err);
   next(err);
 });
-
-
 
 web.set('view engine', 'ejs');
 web.set('views', path.join(app.getPath('userData'), 'views'));
 
 async function build() {
   const base = config.storagePath;
-  const currentVersion = require('../package.json').version;
+  const currentVersion = pkg.version;
   const versionFilePath = path.join(app.getPath('userData'), 'version.txt');
   let lastVersion = '';
   try {
@@ -561,8 +570,8 @@ async function build() {
     if (fs.existsSync(ffmpegZipPath) && !fs.existsSync(ffmpegExePath)) {
       log.info('Extraction de FFmpeg...');
       const extractDir = path.join(app.getPath('userData'), 'ffmpeg-temp');
+      const unzipper = require('unzipper');
       if (process.platform === 'win32') {
-        const unzipper = require('unzipper');
         await fs.createReadStream(ffmpegZipPath)
           .pipe(unzipper.Extract({ path: extractDir }))
           .promise();
@@ -637,16 +646,9 @@ async function build() {
   }
 }
 
-try {
-  
-} catch (error) {
-  log.info(error);
-  log.error(error);
-}
-
-let  promptResponse;
+let promptResponse;
 ipcMain.on('prompt', function(eventRet, arg) {
-   promptResponse = null
+  promptResponse = null
   var promptWindow = new BrowserWindow({
     width: 200,
     height: 100,
@@ -723,7 +725,6 @@ ipcMain.on('prompt', function(eventRet, arg) {
     eventRet.returnValue = promptResponse
     download(promptResponse)
     promptWindow = null
-
   })
 })
 ipcMain.on('prompt-response', function(event, arg) {
@@ -732,13 +733,10 @@ ipcMain.on('prompt-response', function(event, arg) {
   download(promptResponse)
 })
 
-//const download = require('./ytb');
 log.info('boot now');
 
 web.get("/", function (req, res) {
-  // Utilise les données déjà chargées et scorées dans la DB
   const results = [...db.database].sort((a, b) => {
-    // Tri par date de téléchargement (mtime) décroissant
     const dateA = a.mtime || 0;
     const dateB = b.mtime || 0;
     if (dateB !== dateA) return dateB - dateA;
@@ -796,14 +794,13 @@ web.get("/queue/clear", function (req, res) {
 });
 
 web.get("/watch", function (req, res) {
-    const fileData = db.getFile(req.query.id);
+  const fileData = db.getFile(req.query.id);
   
   if (!fileData || !fileData.fileName) {
     download(config.videoUrlFormat.replace('${id}', req.query.id));
     return res.redirect("/");
   }
 
-  // Ajouter à l'historique
   db.addToHistory(req.query.id);
 
   const infoPath = path.join(config.storagePath, fileData.fileName.replace(".mp4", ".info.json"));
@@ -820,7 +817,6 @@ web.get("/watch", function (req, res) {
     try {
       const onDiskData = JSON.parse(fs.readFileSync(infoPath, 'utf8'));
       videodata = { ...videodata, ...onDiskData };
-      // Trigger update metadata in background only if needed
       if (onDiskData.webpage_url) {
         downloaddata(onDiskData.webpage_url);
       }
@@ -840,7 +836,6 @@ web.get("/watch", function (req, res) {
   const currentInQueue = db.queue.includes(req.query.id);
   const isFavorite = db.isFavorite(req.query.id);
 
-  // Check user queue first
   if (db.queue.length > 0) {
     const queueIdx = db.queue.indexOf(req.query.id);
     if (queueIdx !== -1) {
@@ -852,7 +847,6 @@ web.get("/watch", function (req, res) {
     }
   }
 
-  // If no queue, check playlist
   if (!nextVideo && playlistName) {
     const playlist = db.getPlaylist(playlistName);
     if (playlist) {
@@ -863,7 +857,6 @@ web.get("/watch", function (req, res) {
     }
   }
 
-  // Fallback if not in playlist or end of playlist/queue
   if (!nextVideo) {
     const currentIdx = filteredReferencement.findIndex(item => item.yid === req.query.id);
     nextVideo = currentIdx === filteredReferencement.length - 1 ? filteredReferencement[0] : filteredReferencement[currentIdx + 1];
@@ -883,8 +876,8 @@ web.get("/watch", function (req, res) {
     allChannels: db.getAllChannels()
   });
 });
+
 web.get("/download", function (req, res) {
-  console.log(req.query)
   let url = req.query.url;
   if (Array.isArray(url)) {
     url = url[0];
@@ -895,8 +888,8 @@ web.get("/download", function (req, res) {
   download(url);
   res.redirect("/")
 });
+
 web.post("/tag", function (req, res) {
-  console.log(req.body)
   const videoId = req.body.videoId;
   const tag = req.body.tag;
   const videoData = db.getFile(videoId);
@@ -915,11 +908,11 @@ web.post("/tag", function (req, res) {
 
 
 web.get("/delete", function (req, res) {
- // log.info(req.query)
   fs.rmSync(path.join(base, db.getFile( req.query.id).fileName))
   db.save()
   res.redirect("/")
 });
+
 web.get("/api/search", function (req, res) {
   const query = req.query.q || req.query.tags || "";
   const results = db.search(query);
@@ -1037,40 +1030,33 @@ web.get("/playlist/delete", function (req, res) {
 
 
 web.get("/renderer.js",function (req, res) {
-  res.statusCode=200
-  res.send(fs.readFileSync(path.join(app.getPath('userData'), "./src/renderer.js"))) // Correction pour utiliser path.join pour une construction de chemin valide
+  res.statusCode = 200
+  res.send(fs.readFileSync(path.join(app.getPath('userData'), "./src/renderer.js")))
 })
 web.get("/socket.io.js",function (req, res) {
-  res.statusCode=200
+  res.statusCode = 200
   res.send(fs.readFileSync(path.join(app.getPath('userData'), "./src/client-dist/socket.io.js")))
 })
 web.get("/socket.io.js.map",function (req, res) {
-  res.statusCode=200
+  res.statusCode = 200
   res.send(fs.readFileSync(path.join(app.getPath('userData'), "./src/client-dist/socket.io.js.map")))
 })
 web.get("/video", limiter, function (req, res) {
-  log.info(req.query)  
-  log.info(req.headers)
-  // Ensure there is a range given for the video
   const range = req.headers.range;
   if (!range) {
     res.status(400).send("Requires Range header");
   }
- // log.info(db.getFile( req.query.id))
   const fileName = db.getFile(req.query.id).fileName;
   if (fileName.includes('../') || fileName.includes('..\\')) {
     return res.status(400).send("Invalid file name");
   }
   const videoPath = path.join(base, fileName);
-//  log.info(videoPath)
- // log.info(req.query.id)
   const videoSize = fs.statSync(videoPath).size;
 
   const CHUNK_SIZE = 2 * 10 ** 6; // 2MB
   const start = Number(range.replace(/\D/g, ""));
   const end = Math.min(start + CHUNK_SIZE, videoSize - 1);
 
-  // Create headers
   const contentLength = end - start + 1;
   const headers = {
     "Content-Range": `bytes ${start}-${end}/${videoSize}`,
@@ -1079,119 +1065,39 @@ web.get("/video", limiter, function (req, res) {
     "Content-Type": "video/mp4",
   };
 
-  // HTTP Status 206 for Partial Content
   res.writeHead(206, headers);
-
-  // create video read stream for this particular chunk
   const videoStream = fs.createReadStream(videoPath, { start, end });
-
-  // Stream the video chunk to the client
   videoStream.pipe(res);
 });
-function createWindow() {
 
-  
+function createWindow() {
   const mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     backgroundColor: '#080808',
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'), // Correction pour utiliser path.join pour une construction de chemin valide
+      preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       enableRemoteModule: false,
     },
   });
   
-  const menu = Menu.buildFromTemplate([
-    {
-      label: 'Fichier',
-      submenu: [
-        {
-          label: 'Télécharger une vidéo',
-          click() {
-            const { dialog } = require('electron');
-            log.info(dialog)
-         
-          }
-        },
-        { type: 'separator' },
-        { role: 'quit' }
-      ]
-    },
-    {
-      label: 'Édition',
-      submenu: [
-        { role: 'undo' },
-        { role: 'redo' },
-        { type: 'separator' },
-        { role: 'cut' },
-        { role: 'copy' },
-        { role: 'paste' },
-        { role: 'delete' },
-        { role: 'selectall' }
-      ]
-    },
-    {
-      label: 'Affichage',
-      submenu: [
-        { role: 'reload' },
-        { role: 'forcereload' },
-        { role: 'toggledevtools' },
-        { type: 'separator' },
-        { role: 'resetzoom' },
-        { role: 'zoomin' },
-        { role: 'zoomout' },
-        { type: 'separator' },
-        { role: 'togglefullscreen' }
-      ]
-    },
-    {
-      role: 'window',
-      label: 'Fenêtre',
-      submenu: [
-        { role: 'minimize' },
-        { role: 'close' }
-      ]
-    },
-    {
-      role: 'help',
-      label: 'Aide',
-      submenu: [
-        {
-          label: 'A propos de l\'application',
-          click() {
-            dialog.showMessageBox({
-              type: 'info',
-              icon: path.join(__dirname, 'assets/icon.png'),
-              title: 'A propos de l\'application',
-              message: 'Ceci est une application de téléchargement de vidéos.',
-              buttons: ['OK']
-            });
-          }
-        }
-      ]
-    }
-  ]);
-
- // mainWindow.setMenu(menu);
-win=mainWindow
-ipcMain.on('execute-command', (e, arg) => {
-  const  parameter  = arg;
-  log.info(arg)
-  var msg =download(parameter)
- 
-    
-    return msg
-  
-});
+  win = mainWindow;
+  ipcMain.on('execute-command', (e, arg) => {
+    const parameter = arg;
+    log.info(arg);
+    var msg = download(parameter);
+    return msg;
+  });
   mainWindow.loadURL("http://localhost:8001");
 
   mainWindow.on('closed', () => {
-   delete mainWindow
+   win = null;
   });
 }
+
 // Start the application
-http.listen(8001, function () {
+httpServer.listen(8001, function () {
   log.info('Listening on port 8001!');
   booted = true;
   if (app.isReady()) {
@@ -1221,4 +1127,3 @@ app.on('window-all-closed', () => {
     app.quit();
   }
 });
-

--- a/src/main.js
+++ b/src/main.js
@@ -1,1 +1,0 @@
-import { app, BrowserWindow, ipcMain } from 'electron';

--- a/src/main.js
+++ b/src/main.js
@@ -1,1 +1,1 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+import { app, BrowserWindow, ipcMain } from 'electron';

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,4 +1,5 @@
-const { contextBridge, ipcRenderer,ipcMain } = require('electron');
+import { contextBridge, ipcRenderer } from 'electron';
+
 contextBridge.exposeInMainWorld('electronAPI', {
   setTitle: (parameter) => ipcRenderer.send('execute-command', parameter)
-})
+});

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,10 +1,10 @@
-const express = require('express');
+import express from 'express';
 const router = express.Router();
-const controller = require('../controllers/index');
+import * as controller from '../controllers/index.js';
 
 // Define routes and map them to controller functions
 router.get('/', controller.home);
 router.get('/video/:id', controller.getVideo);
 router.post('/video', controller.uploadVideo);
 
-module.exports = router;
+export default router;

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,7 +1,7 @@
-const fs = require('fs');
-const https = require('https');
-const path = require('path');
-const log = require('electron-log');
+import fs from 'fs';
+import https from 'https';
+import path from 'path';
+import log from 'electron-log';
 
 function get(url, dest) {
   return new Promise((resolve, reject) => {
@@ -121,7 +121,7 @@ async function updateFile(url, dest, force = false) {
   }
 }
 
-module.exports = {
+export {
   get,
   updateFile
 };

--- a/src/ytb.js
+++ b/src/ytb.js
@@ -1,13 +1,6 @@
 import fs from 'fs';
 import child_process from 'child_process';
 
-const utf8 = function (str) {
-  const enc = new TextEncoder('utf-8');
-  const u8s = enc.encode(str);
-
-  return Array.from(u8s).map(v => String.fromCharCode(v)).join('');
-}
-
 const path = () => {
   if (fs.existsSync("D:/OS.js-master/vfs/demo")) {
     return "D:/OS.js-master/vfs/demo";
@@ -21,8 +14,12 @@ async function start(answers, folder, logger) {
     return;
   }
 
-  var workerProcess = child_process.exec(
-    `cd ${folder} && ${process.cwd()}\\ytdlp.exe --yes-playlist ${answers}`,
+  const exePath = `${process.cwd()}\\ytdlp.exe`;
+  const args = ["--yes-playlist", answers];
+  var workerProcess = child_process.execFile(
+    exePath,
+    args,
+    { cwd: folder },
     function (error, stdout, stderr) {
       if (error) {
         logger(error.stack);
@@ -42,8 +39,12 @@ async function ide(answers, folder, logger) {
   if (!answers) {
     return;
   }
-  var workerProcess = child_process.exec(
-    ` cd ${folder} && ${process.cwd()}\\ytdlp.exe --yes-playlist ${answers}`,
+  const exePath = `${process.cwd()}\\ytdlp.exe`;
+  const args = ["--yes-playlist", answers];
+  var workerProcess = child_process.execFile(
+    exePath,
+    args,
+    { cwd: folder },
     function (error, stdout, stderr) {
       if (error) {
         logger(error.stack);

--- a/src/ytb.js
+++ b/src/ytb.js
@@ -1,21 +1,28 @@
-﻿const fs = require('fs'),utf8 =function (str) {
+import fs from 'fs';
+import child_process from 'child_process';
+
+const utf8 = function (str) {
   const enc = new TextEncoder('utf-8');
   const u8s = enc.encode(str);
 
   return Array.from(u8s).map(v => String.fromCharCode(v)).join('');
 }
-const path =()=>{
-  if(fs.existsSync("D:/OS.js-master/vfs/demo")){
-    return "D:/OS.js-master/vfs/demo"
-  }else{"C:\\Users\\MPA\\Videos\\file\\"}
+
+const path = () => {
+  if (fs.existsSync("D:/OS.js-master/vfs/demo")) {
+    return "D:/OS.js-master/vfs/demo";
+  } else {
+    return "C:\\Users\\MPA\\Videos\\file\\";
+  }
 }
+
 async function start(answers, folder, logger) {
   if (!answers) {
     return;
   }
 
-  var workerProcess = require("child_process").exec(
-    `cd ${folder} && ${process.cwd}\\ytdlp.exe --yes-playlist ${answers}`,
+  var workerProcess = child_process.exec(
+    `cd ${folder} && ${process.cwd()}\\ytdlp.exe --yes-playlist ${answers}`,
     function (error, stdout, stderr) {
       if (error) {
         logger(error.stack);
@@ -35,8 +42,8 @@ async function ide(answers, folder, logger) {
   if (!answers) {
     return;
   }
-  var workerProcess = require("child_process").exec(
-    ` cd ${folder} && ${process.cwd}\\ytdlp.exe --yes-playlist ${answers}`,
+  var workerProcess = child_process.exec(
+    ` cd ${folder} && ${process.cwd()}\\ytdlp.exe --yes-playlist ${answers}`,
     function (error, stdout, stderr) {
       if (error) {
         logger(error.stack);
@@ -54,13 +61,13 @@ async function ide(answers, folder, logger) {
 
 async function main(n) {}
 
-module.exports = {
-  main: function main(string,  logger) {
-    start(string, path, logger);
+export default {
+  main: function main(string, logger) {
+    start(string, path(), logger);
   },
   cli: main,
   id: function id(string, logger) {
-    ide(string,path, logger);
+    ide(string, path(), logger);
   },
   path: path,
 };

--- a/test-userdata/database.json
+++ b/test-userdata/database.json
@@ -1,1 +1,0 @@
-{"database":[{"fileName":"vid1 [id1].mp4","yid":"id1","tags":[]},{"fileName":"vid2 [id2].mp4","yid":"id2","tags":[]}],"history":["v1","v8","v7","v6","v5","v4","v3","v2"],"playlists":[],"queue":[],"favorites":[]}

--- a/test_binaries.js
+++ b/test_binaries.js
@@ -1,6 +1,6 @@
-const binaryResolver = require('./src/binaryResolver');
-const path = require('path');
-const fs = require('fs');
+import binaryResolver from './src/binaryResolver.js';
+import path from 'path';
+import fs from 'fs';
 
 async function test() {
   console.log('Resolving binaries...');

--- a/test_binaries.js
+++ b/test_binaries.js
@@ -1,6 +1,4 @@
 import binaryResolver from './src/binaryResolver.js';
-import path from 'path';
-import fs from 'fs';
 
 async function test() {
   console.log('Resolving binaries...');

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -1,35 +1,15 @@
-const assert = require('node:assert');
-const { test, mock } = require('node:test');
-const path = require('path');
-const fs = require('fs');
-
-// Mock electron app before requiring db.js
-const mockApp = {
-    getPath: (name) => {
-        if (name === 'userData') return './test-userdata';
-        return './test-dir';
-    }
-};
-
-// Use a proxy or mock for electron
-require.cache[require.resolve('electron')] = {
-    cache: {},
-    exports: {
-        app: mockApp
-    }
-};
-
-const FileDatabase = require('../src/db.js');
+import assert from 'node:assert';
+import { test } from 'node:test';
+import path from 'path';
+import fs from 'fs';
+import FileDatabase from '../src/db.js';
 
 test('FileDatabase should parse filenames correctly', (t) => {
-    // Note: the getid function in db.js seems to have some issues based on its code
-    // Let's see how it behaves.
-    
     // We need to create the test-userdata directory
     const userDataPath = path.resolve('./test-userdata');
     const filesPath = path.resolve('./test-files');
-    if (!fs.existsSync(userDataPath)) fs.mkdirSync(userDataPath);
-    if (!fs.existsSync(filesPath)) fs.mkdirSync(filesPath);
+    if (!fs.existsSync(userDataPath)) fs.mkdirSync(userDataPath, { recursive: true });
+    if (!fs.existsSync(filesPath)) fs.mkdirSync(filesPath, { recursive: true });
     
     const db = new FileDatabase(filesPath);
     

--- a/tests/downloader.test.js
+++ b/tests/downloader.test.js
@@ -1,7 +1,7 @@
-const assert = require('node:assert');
-const { test } = require('node:test');
-const path = require('path');
-const { createDownloadArgs, createMetadataArgs } = require('../src/downloader');
+import assert from 'node:assert';
+import { test } from 'node:test';
+import path from 'path';
+import { createDownloadArgs, createMetadataArgs } from '../src/downloader.js';
 
 test('createDownloadArgs should generate correct arguments', (t) => {
   const parameter = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
@@ -23,7 +23,7 @@ test('createMetadataArgs should generate correct arguments', (t) => {
   const outputFileFormat = '%(title)s [%(id)s].%(ext)s';
   const denoPath = 'C:/bin/deno.exe';
 
-  const args = createMetadataArgs(parameter, storagePath, outputFileFormat, denoPath);
+  const args = createMetadataArgs(parameter, null, storagePath, outputFileFormat, denoPath);
 
   assert.ok(args.includes(parameter));
   assert.ok(args.includes('--simulate'));

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -1,35 +1,26 @@
-const assert = require('node:assert');
-const { test } = require('node:test');
-const path = require('path');
-const fs = require('fs');
+import assert from 'node:assert';
+import { test } from 'node:test';
+import path from 'path';
+import fs from 'fs';
+import { createRequire } from 'module';
 
-// Mock electron app before requiring db.js
-const mockApp = {
-    getPath: (name) => {
-        if (name === 'userData') return './test-history-userdata';
-        return './test-dir';
-    }
-};
+const require = createRequire(import.meta.url);
 
-// Use a proxy or mock for electron
-require.cache[require.resolve('electron')] = {
-    cache: {},
-    exports: {
-        app: mockApp
-    }
-};
+// In ESM, we can't easily mock require.cache for 'electron'
+// So we rely on db.js falling back to process.cwd() or we could try to mock it if needed.
+// For now, we'll just convert the file.
 
-const FileDatabase = require('../src/db.js');
+import FileDatabase from '../src/db.js';
 
 test('FileDatabase should manage history correctly', (t) => {
-    const userDataPath = path.resolve('./test-history-userdata');
+    const userDataPath = path.resolve('./'); // Fallback in db.js when electron is missing
     const filesPath = path.resolve('./test-history-files');
+    const dbFilePath = path.join(userDataPath, 'database.json');
     
     // Clean start
-    if (fs.existsSync(userDataPath)) fs.rmSync(userDataPath, { recursive: true, force: true });
+    if (fs.existsSync(dbFilePath)) fs.unlinkSync(dbFilePath);
     if (fs.existsSync(filesPath)) fs.rmSync(filesPath, { recursive: true, force: true });
     
-    if (!fs.existsSync(userDataPath)) fs.mkdirSync(userDataPath, { recursive: true });
     if (!fs.existsSync(filesPath)) fs.mkdirSync(filesPath, { recursive: true });
     
     const db = new FileDatabase(filesPath);
@@ -68,6 +59,6 @@ test('FileDatabase should manage history correctly', (t) => {
     assert.strictEqual(historyItems[0].yid, "v1");
     
     // Clean up
-    fs.rmSync(userDataPath, { recursive: true, force: true });
+    if (fs.existsSync(dbFilePath)) fs.unlinkSync(dbFilePath);
     fs.rmSync(filesPath, { recursive: true, force: true });
 });

--- a/tests/playlist.test.js
+++ b/tests/playlist.test.js
@@ -1,31 +1,18 @@
-const { test, describe, before, after } = require('node:test');
-const assert = require('node:assert');
-const fs = require("fs");
-const path = require("path");
-const os = require("os");
-
-// Mock electron app before requiring db.js
-const mockApp = {
-    getPath: (name) => {
-        if (name === 'userData') return os.tmpdir();
-        return os.tmpdir();
-    }
-};
-
-require.cache[require.resolve('electron')] = {
-    cache: {},
-    exports: {
-        app: mockApp
-    }
-};
-
-const FileDatabase = require("../src/db");
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from "fs";
+import path from "path";
+import os from "os";
+import FileDatabase from "../src/db.js";
 
 describe("Playlist System", () => {
     let db;
     const tempDir = path.join(os.tmpdir(), "youtube-test-playlists");
+    // Since we can't mock electron easily, db.js will use process.cwd() for database.json
+    const dbPath = path.join(process.cwd(), 'database.json');
 
     before(() => {
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
         if (!fs.existsSync(tempDir)) fs.mkdirSync(tempDir);
         db = new FileDatabase(tempDir);
         // Mock some videos
@@ -33,10 +20,12 @@ describe("Playlist System", () => {
             { fileName: "vid1 [id1].mp4", yid: "id1", tags: [] },
             { fileName: "vid2 [id2].mp4", yid: "id2", tags: [] }
         ];
+        db._buildIndex();
     });
 
     after(() => {
         if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
     });
 
     test("should create a playlist", () => {

--- a/tests/queue.test.js
+++ b/tests/queue.test.js
@@ -1,5 +1,5 @@
-const assert = require('node:assert');
-const { test } = require('node:test');
+import assert from 'node:assert';
+import { test } from 'node:test';
 
 // Mock of the queue logic from src/index.js
 class DownloadQueue {

--- a/tests/updater.test.js
+++ b/tests/updater.test.js
@@ -1,8 +1,8 @@
-const assert = require('node:assert');
-const { test } = require('node:test');
-const fs = require('fs');
-const path = require('path');
-const { updateFile } = require('../src/updater');
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'fs';
+import path from 'path';
+import { updateFile } from '../src/updater.js';
 
 test('updateFile should handle non-existent URLs', async (t) => {
   const url = 'https://this-url-does-not-exist.commmmm/file.exe';

--- a/verify_binaries.js
+++ b/verify_binaries.js
@@ -1,5 +1,6 @@
-const path = require('path');
-const fs = require('fs');
+import path from 'path';
+import fs from 'fs';
+import binaryResolver from './src/binaryResolver.js';
 
 // Mock global app for the resolver
 global.app = {
@@ -9,13 +10,11 @@ global.app = {
     }
 };
 
-const binaryResolver = require('./src/binaryResolver');
-
 async function test() {
     console.log('Resolved Paths:');
     console.log('ytdlp:', binaryResolver.ytdlp);
     console.log('ffmpeg:', binaryResolver.ffmpeg);
-    console.log('bun:', binaryResolver.bun);
+    console.log('deno:', binaryResolver.deno);
     console.log('ffmpegDir:', binaryResolver.ffmpegDir);
 
     console.log('\nValidating Binaries...');


### PR DESCRIPTION
Cette PR migre l'intégralité du projet de CommonJS vers ECMAScript Modules (ESM).

### Changements principaux :
- Ajout de "type": "module" dans package.json.
- Conversion de src/index.js et de tous les modules src/ vers ESM.
- Mise à jour de la logique d'importation de Rollbar pour utiliser createRequire avec un fichier .cjs (plus robuste).
- Migration de tous les tests unitaires vers ESM.
- Validation du build et du démarrage de l'application effectuée avec succès.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the app, server, and tests to ESM, unified the HTTP/Socket.IO stack across entrypoints, and added robust fallbacks for non‑Electron environments. CI now runs tests with Bun and uses a `.cjs` Rollbar config and JUnit XML output.

- **Refactors**
  - Enabled ESM with `"type": "module"`; converted app/server/tests to `import`/`export`; used `fileURLToPath`/`createRequire` for CJS-only modules (e.g., `rollbar.config.cjs`, optional `adm-zip`).
  - Unified HTTP + Socket.IO via `http.createServer` and `new SocketServer` in root `index.js` and `src/index.js`; added `cors` and `morgan`; tightened video stream path checks and headers.
  - Improved Electron fallbacks across `db`, controllers, binary resolver, and `ytb`; `src/ytb.js` now uses `child_process.execFile` with a safe `cwd`; default config is written and returned without `require`.
  - Switched Rollbar config to `rollbar.config.cjs` and updated imports/workflows; cleaned up logs and minor dead code; updated tests to ESM and adjusted Electron assumptions.

- **Migration**
  - Require Node ≥ 18 and Electron ≥ `41`; reinstall deps.
  - CI: use Bun (`oven-sh/setup-bun`), `bun install`, and `bun test` with JUnit XML (`test-results.xml`); mock `rollbar.config.cjs` in workflows.
  - New deps: `cors`, `escape-html`.

<sup>Written for commit cefe4210f2af46325ef4cbbc4d03a7f75f66b226. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

