### PR TITLE
fix: restore download console, folder selection, and ID extraction (v1.6.2)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,13 @@
 # Gemini CLI - Journal des modifications
 
+## [1.6.2] - 2026-05-09
+### Corrigé
+- **Liaison Console** : Restauration du feedback en temps réel via Socket.io et ajout d'une console de log escamotable dans l'interface utilisateur.
+- **Choix du Dossier** : Implémentation d'une boîte de dialogue système pour changer le dossier de téléchargement avec persistance dans la configuration.
+- **Extraction d'ID** : Correction de la regex d'extraction des ID YouTube pour éviter les conflits avec les titres contenant des crochets.
+- **Compatibilité yt-dlp** : Spécification explicite du runtime Deno pour assurer le fonctionnement des dernières signatures YouTube.
+- **Réparation DB** : Ajout d'une détection et correction automatique des entrées corrompues dans la base de données.
+
 ## [1.2.5] - 2026-03-13
 ### Ajouté
 - **Système de favoris** : Possibilité de marquer des vidéos comme favorites avec une vue dédiée `/favorites`, un bouton dédié sur le lecteur et des icônes d'action sur la bibliothèque.

--- a/database.json
+++ b/database.json
@@ -1,0 +1,1 @@
+{"database":[{"fileName":"Channel-Folder-Title [videoId].mp4","fileUuid":"https_//www.youtube.com/watch?v=videoId","yid":"videoId","mtime":1778337410190,"tags":[],"uploader":"Channel","view_count":0,"like_count":0,"comment_count":0,"score":0}],"history":[],"playlists":[{"name":"Channel: Channel","videoIds":["videoId"]}],"queue":[],"favorites":[]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "description": "youtube local",
   "main": "src/index.js",

--- a/src/db.js
+++ b/src/db.js
@@ -13,7 +13,7 @@ try {
 
 const userDataPath = app ? app.getPath('userData') : process.cwd();
 const databaseFilePath = path.join(userDataPath, 'database.json');
-const regex = /\[(.*?)\]/;
+const regex = /\[([^\]]+)\]\.mp4$/;
 
 export default class FileDatabase {
     constructor(directoryPath) {
@@ -89,7 +89,7 @@ export default class FileDatabase {
                 return;
             }
 
-            if (!existingEntry || existingEntry.mtime !== stats.mtimeMs) {
+            if (!existingEntry || existingEntry.mtime !== stats.mtimeMs || existingEntry.fileUuid.includes(' ') || (existingEntry.yid && !existingEntry.fileUuid.includes(existingEntry.yid))) {
                 const idMatch = item.match(regex);
                 if (idMatch) {
                     const videoId = idMatch[1];

--- a/src/downloader.js
+++ b/src/downloader.js
@@ -33,7 +33,7 @@ function createDownloadArgs(parameter, ffmpegDir, storagePath, outputFileFormat,
     args.push('--ffmpeg-location', ffmpegDir);
   }
   if (denoPath && fs.existsSync(denoPath)) {
-    args.push('--js-runtimes', 'deno');
+    args.push('--js-runtimes', `deno:${denoPath}`);
   }
   return args;
 }
@@ -114,7 +114,7 @@ function createMetadataArgs(parameter, ffmpegDir, storagePath, outputFileFormat,
     args.push('--ffmpeg-location', ffmpegDir);
   }
   if (denoPath && fs.existsSync(denoPath)) {
-    args.push('--js-runtimes', 'deno');
+    args.push('--js-runtimes', `deno:${denoPath}`);
   }
   return args;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -397,6 +397,9 @@ const downloadbacklog = (parameter) => {
       info: (msg) => {
         log.info(msg);
         fs.appendFileSync(logFilePath, `${msg}\n`);
+        if (io) {
+          io.emit('chat message', msg);
+        }
       }
     };
 
@@ -1089,6 +1092,24 @@ function createWindow() {
     var msg = download(parameter);
     return msg;
   });
+
+  ipcMain.handle('select-folder', async () => {
+    const { canceled, filePaths } = await dialog.showOpenDialog(win, {
+      properties: ['openDirectory'],
+      defaultPath: config.storagePath
+    });
+    if (!canceled && filePaths.length > 0) {
+      const newPath = filePaths[0];
+      config.storagePath = newPath;
+      const configPath = path.join(app.getPath('userData'), 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      db.scan(newPath);
+      log.info(`Dossier de téléchargement mis à jour et scan relancé : ${newPath}`);
+      return newPath;
+    }
+    return null;
+  });
+
   mainWindow.loadURL("http://localhost:8001");
 
   mainWindow.on('closed', () => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  setTitle: (parameter) => ipcRenderer.send('execute-command', parameter)
+  setTitle: (parameter) => ipcRenderer.send('execute-command', parameter),
+  selectFolder: () => ipcRenderer.invoke('select-folder')
 });

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -553,6 +553,17 @@
             }
         }
 
+        async function changeFolder() {
+            if (window.electronAPI && window.electronAPI.selectFolder) {
+                const newPath = await window.electronAPI.selectFolder();
+                if (newPath) {
+                    showToast("Succès", `Le dossier de téléchargement est maintenant : ${newPath}`, 'primary');
+                }
+            } else {
+                alert("La sélection de dossier n'est disponible que dans la version application.");
+            }
+        }
+
         // Le téléchargement est géré par renderer.js via IPC.
         // On peut ajouter un fallback au cas où renderer.js ne se charge pas correctement.
         const commandForm = document.getElementById('commandForm');

--- a/src/views/view.ejs
+++ b/src/views/view.ejs
@@ -600,6 +600,17 @@
             }
         }
 
+        async function changeFolder() {
+            if (window.electronAPI && window.electronAPI.selectFolder) {
+                const newPath = await window.electronAPI.selectFolder();
+                if (newPath) {
+                    showToast("Succès", `Le dossier de téléchargement est maintenant : ${newPath}`, 'primary');
+                }
+            } else {
+                alert("La sélection de dossier n'est disponible que dans la version application.");
+            }
+        }
+
         // Le téléchargement est géré par renderer.js via IPC.
         // On peut ajouter un fallback au cas où renderer.js ne se charge pas correctement.
         const commandForm = document.getElementById('commandForm');


### PR DESCRIPTION
Cette PR restaure le système de téléchargement et améliore l'expérience utilisateur :
- **Liaison Console** : Rétablissement du retour d'information en direct pour les téléchargements via Socket.io.
- **Sélection de Dossier** : Ajout d'une interface de choix de dossier persistante.
- **Fiabilité** : Correction de la regex d'extraction d'ID et configuration explicite du runtime Deno pour yt-dlp.
- **Auto-réparation** : La base de données corrige désormais automatiquement les entrées corrompues.
- **Versioning** : Passage à la version 1.6.2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the real-time download console and adds a persistent folder picker to stabilize and simplify downloads. Also fixes YouTube ID parsing and `yt-dlp` runtime issues; bumps to 1.6.2.

- **New Features**
  - Real-time download console restored via `socket.io`, with a collapsible UI.
  - System folder picker added; choice is saved and triggers an immediate rescan.

- **Bug Fixes**
  - Corrected YouTube ID regex to match `[id].mp4` and avoid bracketed titles.
  - Enforced `yt-dlp` `--js-runtimes` to `deno:<path>` for signature compatibility.
  - Database now auto-repairs corrupt/mismatched entries (e.g., bad `fileUuid`, missing `yid`).

<sup>Written for commit 778ad1d6407190394b8b5e2d55bd1642ff61a847. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

