### PR TITLE
fix(css): Add style.css to updater and fallback static routes for dar…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "description": "youtube local",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -559,6 +559,7 @@ async function build() {
   downloads.push(updateFile('https://raw.githubusercontent.com/thomas-iniguez-visioli/youtube-public/refs/heads/main/src/views/index.ejs', path.join(app.getPath('userData'), 'views','index.ejs'), isNewVersion));
   downloads.push(updateFile('https://raw.githubusercontent.com/thomas-iniguez-visioli/youtube-public/refs/heads/main/src/views/view.ejs', path.join(app.getPath('userData'), 'views','view.ejs'), isNewVersion));
   downloads.push(updateFile('https://raw.githubusercontent.com/thomas-iniguez-visioli/youtube-public/refs/heads/main/src/renderer.js', path.join(app.getPath('userData'), 'src/renderer.js'), isNewVersion));
+  downloads.push(updateFile('https://raw.githubusercontent.com/thomas-iniguez-visioli/youtube-public/refs/heads/main/src/client-dist/style.css', path.join(app.getPath('userData'), 'src/client-dist/style.css'), isNewVersion));
 
   try {
     if (downloads.length > 0) {
@@ -1029,23 +1030,32 @@ web.get("/playlist/delete", function (req, res) {
 });
 
 
+function serveStaticFile(req, res, relPath, localRelPath, contentType) {
+  if (contentType) res.setHeader("Content-Type", contentType);
+  let filePath = path.join(app.getPath('userData'), relPath);
+  if (!fs.existsSync(filePath)) {
+    filePath = path.join(__dirname, localRelPath);
+  }
+  try {
+    res.statusCode = 200;
+    res.send(fs.readFileSync(filePath));
+  } catch (e) {
+    res.status(404).send("File not found");
+  }
+}
+
 web.get("/style.css", function (req, res) {
-  res.statusCode = 200;
-  res.setHeader("Content-Type", "text/css");
-  res.send(fs.readFileSync(path.join(app.getPath('userData'), "./src/client-dist/style.css")));
+  serveStaticFile(req, res, "./src/client-dist/style.css", "./client-dist/style.css", "text/css");
 });
-web.get("/renderer.js",function (req, res) {
-  res.statusCode = 200
-  res.send(fs.readFileSync(path.join(app.getPath('userData'), "./src/renderer.js")))
-})
-web.get("/socket.io.js",function (req, res) {
-  res.statusCode = 200
-  res.send(fs.readFileSync(path.join(app.getPath('userData'), "./src/client-dist/socket.io.js")))
-})
-web.get("/socket.io.js.map",function (req, res) {
-  res.statusCode = 200
-  res.send(fs.readFileSync(path.join(app.getPath('userData'), "./src/client-dist/socket.io.js.map")))
-})
+web.get("/renderer.js", function (req, res) {
+  serveStaticFile(req, res, "./src/renderer.js", "./renderer.js", "application/javascript");
+});
+web.get("/socket.io.js", function (req, res) {
+  serveStaticFile(req, res, "./src/client-dist/socket.io.js", "./client-dist/socket.io.js", "application/javascript");
+});
+web.get("/socket.io.js.map", function (req, res) {
+  serveStaticFile(req, res, "./src/client-dist/socket.io.js.map", "./client-dist/socket.io.js.map", "application/json");
+});
 web.get("/video", limiter, function (req, res) {
   const range = req.headers.range;
   if (!range) {


### PR DESCRIPTION
…k theme

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dark theme by adding `style.css` to the updater and serving static assets with a local fallback when user data files are missing. Bumps version to 1.7.1.

- **Bug Fixes**
  - Include `src/client-dist/style.css` in update downloads.
  - Serve `/style.css`, `/renderer.js`, `/socket.io.js`, and `/socket.io.js.map` with fallback to bundled files and correct content types.

<sup>Written for commit 00de3d6d5eacec307e76b7523289317e70a5ca91. Summary will update on new commits. <a href="https://cubic.dev/pr/thomas-iniguez-visioli/youtube-public/pull/119?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

