### PR TITLE
perf: optimisations v1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "type": "module",
   "description": "youtube local",
   "main": "src/index.js",

--- a/src/db.js
+++ b/src/db.js
@@ -29,6 +29,8 @@ export default class FileDatabase {
 
     _buildIndex() {
         this.yidMap.clear();
+        this._tagsCache = null;
+        this._channelsCache = null;
         if (Array.isArray(this.database)) {
             this.database.forEach(file => {
                 if (file && file.yid) {
@@ -48,23 +50,25 @@ export default class FileDatabase {
      }
 
     getAllTags() {
+        if (this._tagsCache) return this._tagsCache;
         const tags = new Set();
         this.database.forEach(entry => {
-            if (entry.tags) {
-                entry.tags.forEach(tag => tags.add(tag));
-            }
+            if (entry.tags) entry.tags.forEach(tag => tags.add(tag));
         });
-        return Array.from(tags).sort();
+        this._tagsCache = Array.from(tags).sort();
+        return this._tagsCache;
     }
 
     getAllChannels() {
+        if (this._channelsCache) return this._channelsCache;
         const channels = new Set();
         this.database.forEach(entry => {
             if (entry.uploader && entry.uploader !== 'Uploader inconnu') {
                 channels.add(entry.uploader);
             }
         });
-        return Array.from(channels).sort();
+        this._channelsCache = Array.from(channels).sort();
+        return this._channelsCache;
     }
 
     readDatabase() {
@@ -209,7 +213,7 @@ export default class FileDatabase {
     }
 
     getFile(yid) {
-        return this.yidMap.get(yid) || this.database.find(file => file.yid === yid);
+        return this.yidMap.get(yid) ?? null;
     }
 
     toggleFavorite(videoId) {
@@ -291,6 +295,7 @@ export default class FileDatabase {
             if (!file.tags) file.tags = [];
             if (!file.tags.includes(tag)) {
                 file.tags.push(tag);
+                this._tagsCache = null;
                 this.saveDatabase();
             }
         }
@@ -300,6 +305,7 @@ export default class FileDatabase {
         const file = this.database.find(file => file.yid === yid);
         if (file && file.tags) {
             file.tags = file.tags.filter(t => t !== tag);
+            this._tagsCache = null;
             this.saveDatabase();
         }
     }
@@ -307,6 +313,8 @@ export default class FileDatabase {
     removeFile(yid) {
         this.database = this.database.filter(file => file.yid !== yid);
         if (this.yidMap) this.yidMap.delete(yid);
+        this._tagsCache = null;
+        this._channelsCache = null;
         this.history = this.history.filter(id => id !== yid);
         this.queue = this.queue.filter(id => id !== yid);
         this.favorites = this.favorites.filter(id => id !== yid);

--- a/src/index.js
+++ b/src/index.js
@@ -469,7 +469,7 @@ const processBacklog = async () => {
   }
 };
 
-setInterval(processBacklog, 1000);
+setInterval(processBacklog, 5000);
 
 const accessLogStream = fs.createWriteStream(path.join(app.getPath('userData'), "./log/access-" + `${new Date().toDateString()}` + ".log"));
 const errorLogStream = fs.createWriteStream(path.join(app.getPath('userData'), "./log/error-" + `${new Date().toDateString()}` + ".log"));
@@ -482,8 +482,23 @@ web.use((err, req, res, next) => {
   next(err);
 });
 
+web.use(express.json());
+web.use(express.urlencoded({ extended: false }));
+
 web.set('view engine', 'ejs');
 web.set('views', path.join(app.getPath('userData'), 'views'));
+
+// Helper: rend index.ejs avec les données communes de la DB en une seule passe
+function renderIndex(res, results, channel, channelUrl = null) {
+  res.render('index', {
+    results,
+    channel,
+    channelUrl,
+    playlists: db.getPlaylists(),
+    allTags: db.getAllTags(),
+    allChannels: db.getAllChannels()
+  });
+}
 
 async function build() {
   const base = config.storagePath;
@@ -743,26 +758,10 @@ web.get("/", function (req, res) {
     if (dateB !== dateA) return dateB - dateA;
     return (b.score || 0) - (a.score || 0);
   });
-
-  res.render('index', {
-    results: results,
-    channel: null,
-    channelUrl: null,
-    playlists: db.getPlaylists(),
-    allTags: db.getAllTags(),
-    allChannels: db.getAllChannels()
-  });
+  renderIndex(res, results, null);
 })
 web.get("/queue", function (req, res) {
-  const queue = db.getQueue();
-  res.render('index', {
-    results: queue,
-    channel: "Ma File d'attente",
-    channelUrl: null,
-    playlists: db.getPlaylists(),
-    allTags: db.getAllTags(),
-    allChannels: db.getAllChannels()
-  });
+  renderIndex(res, db.getQueue(), "Ma File d'attente");
 });
 
 web.get("/queue/add", function (req, res) {
@@ -909,9 +908,13 @@ web.post("/tag", function (req, res) {
 
 
 web.get("/delete", function (req, res) {
-  fs.rmSync(path.join(base, db.getFile( req.query.id).fileName))
-  db.save()
-  res.redirect("/")
+  const fileData = db.getFile(req.query.id);
+  if (!fileData) return res.status(404).send("Video not found");
+  const filePath = path.join(base, fileData.fileName);
+  if (fs.existsSync(filePath)) fs.rmSync(filePath);
+  db.removeFile(req.query.id);
+  db.save();
+  res.redirect("/");
 });
 
 web.get("/api/search", function (req, res) {
@@ -924,28 +927,11 @@ web.get("/channel", function (req, res) {
   const channelName = req.query.name;
   const results = db.database.filter(item => item.uploader === channelName);
   const channelUrl = results.length > 0 ? results[0].channel_url : null;
-
-  res.render('index', {
-    results: results,
-    channel: channelName,
-    channelUrl: channelUrl,
-    playlists: db.getPlaylists(),
-    allTags: db.getAllTags(),
-    allChannels: db.getAllChannels()
-  });
+  renderIndex(res, results, channelName, channelUrl);
 });
 
 web.get("/favorites", function (req, res) {
-  const favorites = db.getFavorites();
-
-  res.render('index', {
-    results: favorites,
-    channel: "Mes Favoris",
-    channelUrl: null,
-    playlists: db.getPlaylists(),
-    allTags: db.getAllTags(),
-    allChannels: db.getAllChannels()
-  });
+  renderIndex(res, db.getFavorites(), "Mes Favoris");
 });
 
 web.get("/favorite/toggle", function (req, res) {
@@ -962,43 +948,18 @@ web.get("/favorite/toggle", function (req, res) {
 });
 
 web.get("/history", function (req, res) {
-  const history = db.getHistory();
-
-  res.render('index', {
-    results: history,
-    channel: "Historique",
-    channelUrl: null,
-    playlists: db.getPlaylists(),
-    allTags: db.getAllTags(),
-    allChannels: db.getAllChannels()
-  });
+  renderIndex(res, db.getHistory(), "Historique");
 });
 
 web.get("/playlists", function (req, res) {
-  res.render('index', {
-    results: [],
-    channel: "Mes Playlists",
-    channelUrl: null,
-    playlists: db.getPlaylists(),
-    allTags: db.getAllTags(),
-    allChannels: db.getAllChannels()
-  });
+  renderIndex(res, [], "Mes Playlists");
 });
 
 web.get("/playlist", function (req, res) {
   const name = req.query.name;
   const playlist = db.getPlaylist(name);
-  
   if (!playlist) return res.redirect("/playlists");
-
-  res.render('index', {
-    results: playlist.videos,
-    channel: `Playlist : ${name}`,
-    channelUrl: null,
-    playlists: db.getPlaylists(),
-    allTags: db.getAllTags(),
-    allChannels: db.getAllChannels()
-  });
+  renderIndex(res, playlist.videos, `Playlist : ${name}`);
 });
 
 web.post("/playlist/create", function (req, res) {
@@ -1058,31 +1019,28 @@ web.get("/socket.io.js.map", function (req, res) {
 });
 web.get("/video", limiter, function (req, res) {
   const range = req.headers.range;
-  if (!range) {
-    res.status(400).send("Requires Range header");
-  }
-  const fileName = db.getFile(req.query.id).fileName;
-  if (fileName.includes('../') || fileName.includes('..\\')) {
-    return res.status(400).send("Invalid file name");
-  }
-  const videoPath = path.join(base, fileName);
-  const videoSize = fs.statSync(videoPath).size;
+  if (!range) return res.status(400).send("Requires Range header");
 
+  const fileData = db.getFile(req.query.id);
+  if (!fileData || !fileData.fileName) return res.status(404).send("Video not found");
+
+  const fileName = path.basename(fileData.fileName); // strip any path components
+  const videoPath = path.join(base, fileName);
+  if (!videoPath.startsWith(base)) return res.status(400).send("Invalid file path");
+  if (!fs.existsSync(videoPath)) return res.status(404).send("File not found on disk");
+
+  const videoSize = fs.statSync(videoPath).size;
   const CHUNK_SIZE = 2 * 10 ** 6; // 2MB
   const start = Number(range.replace(/\D/g, ""));
   const end = Math.min(start + CHUNK_SIZE, videoSize - 1);
 
-  const contentLength = end - start + 1;
-  const headers = {
+  res.writeHead(206, {
     "Content-Range": `bytes ${start}-${end}/${videoSize}`,
     "Accept-Ranges": "bytes",
-    "Content-Length": contentLength,
+    "Content-Length": end - start + 1,
     "Content-Type": "video/mp4",
-  };
-
-  res.writeHead(206, headers);
-  const videoStream = fs.createReadStream(videoPath, { start, end });
-  videoStream.pipe(res);
+  });
+  fs.createReadStream(videoPath, { start, end }).pipe(res);
 });
 
 function createWindow() {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,23 +1,144 @@
+// Shared renderer utilities (loaded before page scripts in both views)
 
-// Function to handle video streaming
-function streamVideo(videoId) {
-    window.electronAPI.send('stream-video', videoId);
-}
 document.addEventListener('DOMContentLoaded', () => {
-    // Initialize application
-
-    // Set up event listeners
-    const form = document.getElementById('commandForm');    form.addEventListener('submit', (event) => {
-      event.preventDefault();
-      const parameter = document.getElementById('commandInput').value;
-      window.electronAPI.setTitle(parameter)
-    });
-  });
-/*
-// Function to handle user interactions
-document.getElementById('playButton').addEventListener('click', () => {
-    const videoId = document.getElementById('videoIdInput').value;
-    streamVideo(videoId);
+    const form = document.getElementById('commandForm');
+    if (form) {
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            const url = document.getElementById('commandInput').value;
+            if (window.electronAPI) {
+                window.electronAPI.setTitle(url);
+            } else {
+                window.location.href = `/download?url=${encodeURIComponent(url)}`;
+            }
+        });
+    }
 });
-*/
-// Function to receive messages from the main process
+
+// --- Debounce utility ---
+function debounce(fn, delay) {
+    let timer;
+    return function(...args) {
+        clearTimeout(timer);
+        timer = setTimeout(() => fn.apply(this, args), delay);
+    };
+}
+
+// --- Toast Notifications ---
+function showToast(title, message, type = 'primary', link = null) {
+    const toastContainer = document.querySelector('.toast-container');
+    if (!toastContainer) return;
+
+    const toastId = 'toast-' + Date.now() + Math.floor(Math.random() * 1000);
+    const bgClass = type === 'error' ? 'bg-danger' : 'bg-primary';
+    const btnClass = type === 'error' ? 'btn-danger' : 'btn-primary';
+
+    toastContainer.insertAdjacentHTML('beforeend', `
+        <div id="${toastId}" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="15000">
+            <div class="toast-header ${bgClass} text-white">
+                <strong class="me-auto">${title}</strong>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+            <div class="toast-body">
+                ${message}
+                ${link ? `<div class="mt-2 pt-2 border-top"><a href="${link.url}" class="btn ${btnClass} btn-sm">${link.text}</a></div>` : ''}
+            </div>
+        </div>
+    `);
+
+    const toastEl = document.getElementById(toastId);
+    const toast = new bootstrap.Toast(toastEl);
+    toast.show();
+    toastEl.addEventListener('hidden.bs.toast', () => toastEl.remove());
+}
+
+// --- Queue ---
+async function addToQueue(videoId) {
+    try {
+        const data = await fetch(`/queue/add?id=${videoId}`, { headers: { Accept: 'application/json' } }).then(r => r.json());
+        if (data.success) {
+            const btn = document.querySelector('a[href="/queue"]');
+            if (btn) btn.textContent = `File (${data.queueCount})`;
+        }
+    } catch (err) {
+        console.error('Erreur ajout file :', err);
+    }
+}
+
+// --- Favorites ---
+async function toggleFavorite(videoId, btn) {
+    try {
+        const data = await fetch(`/favorite/toggle?id=${videoId}`, { headers: { Accept: 'application/json' } }).then(r => r.json());
+        if (!data.success) return;
+
+        const favNav = document.querySelector('a[href="/favorites"]');
+        if (favNav) favNav.textContent = `Favoris (${data.favoritesCount})`;
+
+        // View page uses #favoriteBtn, index page passes the button element
+        const favBtn = btn || document.getElementById('favoriteBtn');
+        if (favBtn) {
+            if (data.isFavorite) {
+                favBtn.classList.replace('btn-outline-danger', 'btn-danger');
+                if (favBtn.id === 'favoriteBtn') favBtn.textContent = '❤ Favori';
+            } else {
+                favBtn.classList.replace('btn-danger', 'btn-outline-danger');
+                if (favBtn.id === 'favoriteBtn') favBtn.textContent = '♡ Favori';
+                // On favorites page, remove the card
+                if (typeof channel !== 'undefined' && channel === 'Mes Favoris') {
+                    favBtn.closest('.video-item')?.remove();
+                }
+            }
+        }
+    } catch (err) {
+        console.error('Erreur toggle favori :', err);
+    }
+}
+
+// --- Channel download ---
+function downloadChannel(url) {
+    if (window.electronAPI && window.electronAPI.setTitle) {
+        window.electronAPI.setTitle(url);
+        showToast('Téléchargement', 'Téléchargement de la chaîne lancé !', 'primary');
+    } else {
+        window.location.href = `/download?url=${encodeURIComponent(url)}`;
+    }
+}
+
+// --- Folder picker ---
+async function changeFolder() {
+    if (window.electronAPI && window.electronAPI.selectFolder) {
+        const newPath = await window.electronAPI.selectFolder();
+        if (newPath) showToast('Succès', `Le dossier de téléchargement est maintenant : ${newPath}`, 'primary');
+    } else {
+        alert("La sélection de dossier n'est disponible que dans la version application.");
+    }
+}
+
+// --- Socket.io notifications (shared) ---
+if (typeof io !== 'undefined') {
+    const socket = io();
+    socket.on('error-notification', (data) => showToast('Erreur', data.message, 'error'));
+    socket.on('download-finished', (data) => {
+        showToast(
+            'Téléchargement terminé',
+            `<span class="fw-bold">${data.title}</span> est maintenant disponible.`,
+            'primary',
+            { url: `/watch?id=${data.videoId}`, text: 'Regarder' }
+        );
+    });
+    socket.on('chat message', (msg) => {
+        const consoleLogs = document.getElementById('consoleLogs');
+        const downloadConsole = document.getElementById('downloadConsole');
+        if (downloadConsole && consoleLogs) {
+            downloadConsole.style.display = 'block';
+            msg.split(/\r?\n/).filter(l => l.trim()).forEach(line => {
+                const div = document.createElement('div');
+                div.className = 'mb-1 border-bottom border-secondary pb-1';
+                div.textContent = line;
+                consoleLogs.appendChild(div);
+            });
+            while (consoleLogs.children.length > 100) consoleLogs.removeChild(consoleLogs.firstChild);
+            downloadConsole.scrollTop = downloadConsole.scrollHeight;
+        }
+    });
+}

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -22,58 +22,7 @@
 
 
     <script>
-        // Notification Helper
-        function showToast(title, message, type = 'primary', link = null) {
-            const toastContainer = document.querySelector('.toast-container');
-            if (!toastContainer) return;
-
-            const toastId = 'toast-' + Date.now() + Math.floor(Math.random() * 1000);
-            const bgClass = type === 'error' ? 'bg-danger' : 'bg-primary';
-            const btnClass = type === 'error' ? 'btn-danger' : 'btn-primary';
-
-            const toastHtml = `
-                <div id="${toastId}" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="15000">
-                    <div class="toast-header ${bgClass} text-white">
-                        <strong class="me-auto">${title}</strong>
-                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>
-                    </div>
-                    <div class="toast-body">
-                        ${message}
-                        ${link ? `<div class="mt-2 pt-2 border-top">
-                            <a href="${link.url}" class="btn ${btnClass} btn-sm">${link.text}</a>
-                        </div>` : ''}
-                    </div>
-                </div>
-            `;
-            
-            toastContainer.insertAdjacentHTML('beforeend', toastHtml);
-            const toastElement = document.getElementById(toastId);
-            const toast = new bootstrap.Toast(toastElement);
-            toast.show();
-
-            toastElement.addEventListener('hidden.bs.toast', () => {
-                toastElement.remove();
-            });
-        }
-
-        // Socket.io initialization
-        if (typeof io !== 'undefined') {
-            const socket = io();
-            socket.on('error-notification', (data) => {
-                showToast("Erreur", data.message, 'error');
-            });
-
-            socket.on('download-finished', (data) => {
-                showToast("Téléchargement terminé", `<span class="fw-bold">${data.title}</span> est maintenant disponible.`, 'primary', {
-                    url: `/watch?id=${data.videoId}`,
-                    text: 'Regarder'
-                });
-            });
-
-            socket.on('db-updated', () => {
-                // Database updated
-            });
-        }
+        // Socket.io and shared utilities are initialized in renderer.js
     </script>
 
 </head>
@@ -242,7 +191,7 @@
                 col.innerHTML = `
                     <div class="video-card" onclick="location.href='/watch?id=${result.yid}${playlistParam}'">
                         <div class="video-thumb-container">
-                            <img src="https://img.youtube.com/vi/${result.yid}/hqdefault.jpg" class="video-thumbnail" alt="Thumbnail">
+                            <img data-src="https://img.youtube.com/vi/${result.yid}/hqdefault.jpg" src="" class="video-thumbnail lazy" alt="Thumbnail" loading="lazy">
                         </div>
                         <div class="video-info">
                             <div class="video-details w-100">
@@ -274,11 +223,6 @@
             }
         }
 
-        loadMoreBtn.addEventListener('click', () => {
-            currentPage++;
-            renderVideos(true);
-        });
-
         // Initialize Fuse.js for search
         const fuse = new Fuse(allVideos, {
             keys: ['fileName', 'uploader'],
@@ -287,89 +231,55 @@
             ignoreLocation: true
         });
 
-        searchInput.addEventListener('input', function() {
-            const query = this.value.trim();
-            
-            if (query.length === 0) {
-                filteredVideos = [...allVideos];
-            } else {
-                const results = fuse.search(query);
-                filteredVideos = results.map(r => r.item);
-            }
-            renderVideos();
+        // Lazy-load thumbnails with IntersectionObserver
+        const thumbObserver = new IntersectionObserver((entries, obs) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    const img = entry.target;
+                    img.src = img.dataset.src;
+                    img.classList.remove('lazy');
+                    obs.unobserve(img);
+                }
+            });
+        }, { rootMargin: '200px' });
+
+        function observeLazyImages() {
+            document.querySelectorAll('img.lazy').forEach(img => thumbObserver.observe(img));
+        }
+
+        // Initial render
+        renderVideos();
+        observeLazyImages();
+
+        loadMoreBtn.addEventListener('click', () => {
+            currentPage++;
+            renderVideos(true);
+            observeLazyImages();
         });
+
+        // Debounced fuzzy search
+        searchInput.addEventListener('input', debounce(function() {
+            const query = this.value.trim();
+            filteredVideos = query.length === 0 ? [...allVideos] : fuse.search(query).map(r => r.item);
+            renderVideos();
+            observeLazyImages();
+        }, 250));
 
         function filterByTag(tag, element) {
             document.querySelectorAll('.filter-chip').forEach(chip => chip.classList.remove('active'));
             element.classList.add('active');
-
-            if (tag === 'all') {
-                filteredVideos = [...allVideos];
-            } else {
-                filteredVideos = allVideos.filter(v => v.tags.includes(tag));
-            }
+            filteredVideos = tag === 'all' ? [...allVideos] : allVideos.filter(v => v.tags.includes(tag));
             renderVideos();
+            observeLazyImages();
         }
 
         function filterByChannel(uploader, element) {
             document.querySelectorAll('.filter-chip').forEach(chip => chip.classList.remove('active'));
             element.classList.add('active');
-
-            if (uploader === 'all') {
-                filteredVideos = [...allVideos];
-            } else {
-                filteredVideos = allVideos.filter(v => v.uploader === uploader);
-            }
+            filteredVideos = uploader === 'all' ? [...allVideos] : allVideos.filter(v => v.uploader === uploader);
             renderVideos();
+            observeLazyImages();
         }
-
-        async function addToQueue(videoId) {
-            try {
-                const response = await fetch(`/queue/add?id=${videoId}`, {
-                    headers: { 'Accept': 'application/json' }
-                });
-                const data = await response.json();
-                if (data.success) {
-                    const queueBtn = document.querySelector('a[href="/queue"]');
-                    if (queueBtn) {
-                        queueBtn.textContent = `File (${data.queueCount})`;
-                    }
-                }
-            } catch (err) {
-                console.error("Erreur ajout file :", err);
-            }
-        }
-
-        async function toggleFavorite(videoId, btn) {
-            try {
-                const response = await fetch(`/favorite/toggle?id=${videoId}`, {
-                    headers: { 'Accept': 'application/json' }
-                });
-                const data = await response.json();
-                if (data.success) {
-                    const favBtn = document.querySelector('a[href="/favorites"]');
-                    if (favBtn) {
-                        favBtn.textContent = `Favoris (${data.favoritesCount})`;
-                    }
-                    if (data.isFavorite) {
-                        btn.classList.remove('btn-outline-danger');
-                        btn.classList.add('btn-danger');
-                    } else {
-                        btn.classList.remove('btn-danger');
-                        btn.classList.add('btn-outline-danger');
-                        // Si on est sur la page des favoris, on retire l'élément de la liste
-                        if (channel === "Mes Favoris") {
-                            btn.closest('.video-item').remove();
-                        }
-                    }
-                }
-            } catch (err) {
-                console.error("Erreur toggle favori :", err);
-            }
-        }
-
-        // Initial render
-        renderVideos();
 
         // Gestion du retour à la dernière page visitée
         (function() {
@@ -394,26 +304,6 @@
             sessionStorage.setItem(sessionNavKey, 'true');
             localStorage.setItem(lastUrlKey, currentUrl);
         })();
-
-        function downloadChannel(url) {
-            if (window.electronAPI && window.electronAPI.setTitle) {
-                window.electronAPI.setTitle(url);
-                showToast("Téléchargement", "Téléchargement de la chaîne lancé !", 'primary');
-            } else {
-                window.location.href = `/download?url=${encodeURIComponent(url)}`;
-            }
-        }
-
-        async function changeFolder() {
-            if (window.electronAPI && window.electronAPI.selectFolder) {
-                const newPath = await window.electronAPI.selectFolder();
-                if (newPath) {
-                    showToast("Succès", `Le dossier de téléchargement est maintenant : ${newPath}`, 'primary');
-                }
-            } else {
-                alert("La sélection de dossier n'est disponible que dans la version application.");
-            }
-        }
 
         // Le téléchargement est géré par renderer.js via IPC.
         // On peut ajouter un fallback au cas où renderer.js ne se charge pas correctement.

--- a/src/views/view.ejs
+++ b/src/views/view.ejs
@@ -17,71 +17,7 @@
     <script src="renderer.js"></script>
 
     <script>
-        // Notification Helper
-        function showToast(title, message, type = 'primary', link = null) {
-            const toastContainer = document.querySelector('.toast-container');
-            if (!toastContainer) return;
-
-            const toastId = 'toast-' + Date.now() + Math.floor(Math.random() * 1000);
-            const bgClass = type === 'error' ? 'bg-danger' : 'bg-primary';
-            const btnClass = type === 'error' ? 'btn-danger' : 'btn-primary';
-
-            const toastHtml = `
-                <div id="${toastId}" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="15000">
-                    <div class="toast-header ${bgClass} text-white">
-                        <strong class="me-auto">${title}</strong>
-                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>
-                    </div>
-                    <div class="toast-body">
-                        ${message}
-                        ${link ? `<div class="mt-2 pt-2 border-top">
-                            <a href="${link.url}" class="btn ${btnClass} btn-sm">${link.text}</a>
-                        </div>` : ''}
-                    </div>
-                </div>
-            `;
-            
-            toastContainer.insertAdjacentHTML('beforeend', toastHtml);
-            const toastElement = document.getElementById(toastId);
-            const toast = new bootstrap.Toast(toastElement);
-            toast.show();
-
-            toastElement.addEventListener('hidden.bs.toast', () => {
-                toastElement.remove();
-            });
-        }
-
-        // Socket.io initialization
-        if (typeof io !== 'undefined') {
-            const socket = io();
-            socket.on('error-notification', (data) => {
-                showToast("Erreur", data.message, 'error');
-            });
-
-            socket.on('download-finished', (data) => {
-                showToast("Téléchargement terminé", `<span class="fw-bold">${data.title}</span> est maintenant disponible.`, 'primary', {
-                    url: `/watch?id=${data.videoId}`,
-                    text: 'Regarder'
-                });
-            });
-
-            socket.on('chat message', (msg) => {
-                const consoleLogs = document.getElementById('consoleLogs');
-                const downloadConsole = document.getElementById('downloadConsole');
-                if (downloadConsole && consoleLogs) {
-                    downloadConsole.style.display = 'block';
-                    const lines = msg.split(/\r?\n/).filter(line => line.trim().length > 0);
-                    lines.forEach(line => {
-                        const logLine = document.createElement('div');
-                        logLine.className = 'mb-1 border-bottom border-secondary pb-1';
-                        logLine.textContent = line;
-                        consoleLogs.appendChild(logLine);
-                    });
-                    while (consoleLogs.children.length > 100) consoleLogs.removeChild(consoleLogs.firstChild);
-                    downloadConsole.scrollTop = downloadConsole.scrollHeight;
-                }
-            });
-        }
+        // Socket.io and shared utilities are initialized in renderer.js
     </script>
 
 
@@ -214,7 +150,7 @@
                 %>
                     <a href="/watch?id=<%= v.yid %>" class="suggestion-card d-flex align-items-center justify-content-between w-100">
                         <div class="d-flex">
-                            <img src="https://img.youtube.com/vi/<%= v.yid %>/hqdefault.jpg" class="suggestion-thumb" alt="<%= v.fileName %>">
+                            <img src="https://img.youtube.com/vi/<%= v.yid %>/hqdefault.jpg" loading="lazy" class="suggestion-thumb" alt="<%= v.fileName %>">
                             <div class="suggestion-info">
                                 <span class="suggestion-title"><%= v.fileName %></span>
                                 <span class="suggestion-channel">Voir la vidéo</span>
@@ -357,89 +293,19 @@
             }
         }
 
-        async function addToQueue(videoId) {
-            try {
-                const response = await fetch(`/queue/add?id=${videoId}`, {
-                    headers: { 'Accept': 'application/json' }
-                });
-                const data = await response.json();
-                if (data.success) {
-                    const queueBtn = document.querySelector('a[href="/queue"]');
-                    if (queueBtn) {
-                        queueBtn.textContent = `File (${data.queueCount})`;
-                    }
-                }
-            } catch (err) {
-                console.error("Erreur ajout file :", err);
-            }
-        }
-
-        async function toggleFavorite(videoId) {
-            try {
-                const response = await fetch(`/favorite/toggle?id=${videoId}`, {
-                    headers: { 'Accept': 'application/json' }
-                });
-                const data = await response.json();
-                if (data.success) {
-                    const favBtn = document.getElementById('favoriteBtn');
-                    const favNavBtn = document.querySelector('a[href="/favorites"]');
-                    
-                    if (favNavBtn) {
-                        favNavBtn.textContent = `Favoris (${data.favoritesCount})`;
-                    }
-
-                    if (data.isFavorite) {
-                        favBtn.classList.remove('btn-outline-danger');
-                        favBtn.classList.add('btn-danger');
-                        favBtn.textContent = '❤ Favori';
-                    } else {
-                        favBtn.classList.remove('btn-danger');
-                        favBtn.classList.add('btn-outline-danger');
-                        favBtn.textContent = '♡ Favori';
-                    }
-                }
-            } catch (err) {
-                console.error("Erreur toggle favori :", err);
-            }
-        }
-
         async function shareVideo(url) {
             try {
                 await navigator.clipboard.writeText(url);
                 const shareBtn = document.activeElement;
                 const originalText = shareBtn.textContent;
                 shareBtn.textContent = '✓ Copié !';
-                shareBtn.classList.remove('btn-outline-info');
-                shareBtn.classList.add('btn-info');
-                
+                shareBtn.classList.replace('btn-outline-info', 'btn-info');
                 setTimeout(() => {
                     shareBtn.textContent = originalText;
-                    shareBtn.classList.remove('btn-info');
-                    shareBtn.classList.add('btn-outline-info');
+                    shareBtn.classList.replace('btn-info', 'btn-outline-info');
                 }, 2000);
             } catch (err) {
-                console.error("Erreur partage :", err);
                 alert("Lien YouTube : " + url);
-            }
-        }
-
-        function downloadChannel(url) {
-            if (window.electronAPI && window.electronAPI.setTitle) {
-                window.electronAPI.setTitle(url);
-                showToast("Téléchargement", "Téléchargement de la chaîne lancé !", 'primary');
-            } else {
-                window.location.href = `/download?url=${encodeURIComponent(url)}`;
-            }
-        }
-
-        async function changeFolder() {
-            if (window.electronAPI && window.electronAPI.selectFolder) {
-                const newPath = await window.electronAPI.selectFolder();
-                if (newPath) {
-                    showToast("Succès", `Le dossier de téléchargement est maintenant : ${newPath}`, 'primary');
-                }
-            } else {
-                alert("La sélection de dossier n'est disponible que dans la version application.");
             }
         }
 


### PR DESCRIPTION
- renderIndex helper: factorise les 8 routes EJS dupliquees
- express.json/urlencoded: fix parsing req.body sur les routes POST
- /delete: guard null + removeFile propre + existsSync avant rmSync
- /video: path traversal fix via path.basename + guard null
- processBacklog: interval reduit de 1s a 5s
- db: cache getAllTags/getAllChannels, invalide precisement
- db: getFile O(1) via Map, fallback O(n) supprime
- frontend: lazy-load thumbnails via IntersectionObserver
- frontend: showToast/addToQueue/toggleFavorite/etc centralises dans renderer.js
- frontend: debounce 250ms sur la recherche fuzzy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves app performance and UX while hardening file/video routes. Pages render with less duplicate logic, searches feel snappier, and POST/body parsing is fixed.

- **Refactors**
  - Server: consolidated EJS rendering via `renderIndex`; cached tags/channels with precise invalidation; `getFile` is now O(1) via Map; backlog processing interval increased to 5s.
  - Frontend: lazy-loaded thumbnails with IntersectionObserver; 250ms debounced fuzzy search; centralized `showToast`, `addToQueue`, `toggleFavorite`, and related helpers in `renderer.js`.

- **Bug Fixes**
  - Enabled `express.json()` and `express.urlencoded()` to correctly parse `req.body` on POST routes.
  - Hardened `/video` and `/delete`: null guards, `path.basename` to prevent traversal, and `existsSync` before `rmSync`.

<sup>Written for commit 61140f0ec20d2a5fe14946759a38521df3573763. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thomas-iniguez-visioli/youtube-public/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

